### PR TITLE
Erik Kline's Discuss on draft-ietf-roll-useofrplinfo-42: (with DISCUS…

### DIFF
--- a/roll-useofrplinfo.txt
+++ b/roll-useofrplinfo.txt
@@ -6,9 +6,9 @@ ROLL Working Group                                             M. Robles
 Internet-Draft                                             UTN-FRM/Aalto
 Updates: 6553, 6550, 8138 (if approved)                    M. Richardson
 Intended status: Standards Track                                     SSW
-Expires: March 25, 2021                                       P. Thubert
+Expires: July 10, 2021                                        P. Thubert
                                                                    Cisco
-                                                      September 21, 2020
+                                                         January 6, 2020
 
 
 Using RPI Option Type, Routing Header for Source Routes and IPv6-in-IPv6
@@ -26,7 +26,7 @@ Abstract
    design efficient compression of these headers.  This document updates
    RFC6553 adding a change to the RPI Option Type.  Additionally, this
    document updates RFC6550 defining a flag in the DIO Configuration
-   option to indicate about this change and updates [RFC8138] as well to
+   option to indicate about this change and updates RFC8138 as well to
    consider the new Option Type when the RPL Option is decompressed.
 
 Status of This Memo
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 25, 2021.
+   This Internet-Draft will expire on July 10, 2021.
 
 
 
@@ -53,9 +53,9 @@ Status of This Memo
 
 
 
-Robles, et al.           Expires March 25, 2021                 [Page 1]
+Robles, et al.            Expires July 10, 2021                 [Page 1]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 Copyright Notice
@@ -79,16 +79,16 @@ Table of Contents
      1.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   4
    2.  Terminology and Requirements Language . . . . . . . . . . . .   5
    3.  RPL Overview  . . . . . . . . . . . . . . . . . . . . . . . .   6
-   4.  Updates to RFC6553, RFC6550 and RFC8138 . . . . . . . . . . .   7
-     4.1.  Updates to RFC6550: Advertising External Routes with Non-
-           Storing Mode Signaling. . . . . . . . . . . . . . . . . .   7
-     4.2.  Updates to RFC6553: Indicating the new RPI Option Type. .   8
-     4.3.  Updates to RFC6550:
-           Configuration Options and Mode
-           of Operation  . . . . . . . . . . . . . . . . . . . . . .  11
-     4.4.  Updates to RFC6550: Indicating the new RPI in the
-           DODAG Configuration option Flag.  . . . . . . . . . . . .  12
-     4.5.  Updates to RFC8138: Indicating the way to decompress with
+   4.  Updates to RFC6550, RFC6553 and RFC8138 . . . . . . . . . . .   7
+     4.1.  Updates to RFC6550  . . . . . . . . . . . . . . . . . . .   7
+       4.1.1.  Advertising External Routes with Non-Storing Mode
+               Signaling.  . . . . . . . . . . . . . . . . . . . . .   7
+       4.1.2.  Configuration Options and Mode
+               of Operation  . . . . . . . . . . . . . . . . . . . .   8
+       4.1.3.  Indicating the new RPI in the
+               DODAG Configuration option Flag.  . . . . . . . . . .   9
+     4.2.  Updates to RFC6553: Indicating the new RPI Option Type. .  10
+     4.3.  Updates to RFC8138: Indicating the way to decompress with
            the new RPI Option Type.  . . . . . . . . . . . . . . . .  13
    5.  Sample/reference topology . . . . . . . . . . . . . . . . . .  14
    6.  Use cases . . . . . . . . . . . . . . . . . . . . . . . . . .  16
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Robles, et al.           Expires March 25, 2021                 [Page 2]
+Robles, et al.            Expires July 10, 2021                 [Page 2]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
        7.3.3.  SM: Example of Flow from RUL to RAL . . . . . . . . .  33
@@ -137,7 +137,7 @@ Internet-Draft               RPL-data-plane               September 2020
    10. Operational considerations of introducing 0x23  . . . . . . .  54
    11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  54
      11.1.  Option Type in RPL Option  . . . . . . . . . . . . . . .  54
-     11.2.  Changes to DODAG Configuration Options Flags . . . . . .  55
+     11.2.  Change to the DODAG Configuration Options Flags registry  55
      11.3.  Change MOP value 7 to Reserved . . . . . . . . . . . . .  55
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  55
    13. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  59
@@ -165,9 +165,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                 [Page 3]
+Robles, et al.            Expires July 10, 2021                 [Page 3]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    traffic at all which is mostly Hop-by-Hop traffic (one exception
@@ -198,10 +198,9 @@ Internet-Draft               RPL-data-plane               September 2020
    IPv6 packet encapsulation.  When encapsulating and decapsulating
    packets, RFC 6040 [RFC6040] MUST be applied to map the setting of the
    explicit congestion notification (ECN) field between inner and outer
-   headers.  Additionally, it is recommended the reading of
-   [I-D.ietf-intarea-tunnels] that explains the relationship of IP
-   tunnels to existing protocol layers and the challenges in supporting
-   IP tunneling.
+   headers.  Additionally, [I-D.ietf-intarea-tunnels] is recommended
+   reading to explains the relationship of IP tunnels to existing
+   protocol layers and the challenges in supporting IP tunneling.
 
    Non-constrained uses of RPL are not in scope of this document, and
    applicability statements for those uses may provide different advice,
@@ -217,17 +216,15 @@ Internet-Draft               RPL-data-plane               September 2020
    mode cases and section 8 the non-storing mode cases.  Section 9
    describes the operational considerations of supporting RPL-unaware-
    leaves.  Section 10 depicts operational considerations for the
-
-
-
-
-Robles, et al.           Expires March 25, 2021                 [Page 4]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    proposed change on RPI Option Type, section 11 the IANA
    considerations and then section 12 describes the security aspects.
+
+
+
+Robles, et al.            Expires July 10, 2021                 [Page 4]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
 
 2.  Terminology and Requirements Language
 
@@ -239,6 +236,11 @@ Internet-Draft               RPL-data-plane               September 2020
 
    Terminology defined in [RFC7102] applies to this document: LLN, RPL,
    RPL domain and ROLL.
+
+   Consumed: A Routing Header is consumed when the Segments Left field
+   is zero, which indicates that the destination in the IPv6 header is
+   the final destination of the packet and that the hops in the Routing
+   Header have been traversed.
 
    RPL Leaf: An IPv6 host that is attached to a RPL router and obtains
    connectivity through a RPL Destination Oriented Directed Acyclic
@@ -271,17 +273,18 @@ Internet-Draft               RPL-data-plane               September 2020
    referring to situations in which either a host or router can play the
    role described.".  In this document, a 6LN acts as a leaf.
 
+
+
+
+
+Robles, et al.            Expires July 10, 2021                 [Page 5]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    6LoWPAN Router (6LR): [RFC6775] defines it as:" An intermediate
    router in the LoWPAN that is able to send and receive Router
    Advertisements (RAs) and Router Solicitations (RSs) as well as
-
-
-
-Robles, et al.           Expires March 25, 2021                 [Page 5]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    forward and route IPv6 packets.  6LoWPAN routers are present only in
    route-over topologies."
 
@@ -330,12 +333,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-
-
-
-Robles, et al.           Expires March 25, 2021                 [Page 6]
+Robles, et al.            Expires July 10, 2021                 [Page 6]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +--------------+
@@ -367,10 +367,11 @@ Internet-Draft               RPL-data-plane               September 2020
    nodes is not supported with the current specifications at the time of
    writing this document.
 
-4.  Updates to RFC6553, RFC6550 and RFC8138
+4.  Updates to RFC6550, RFC6553 and RFC8138
 
-4.1.  Updates to RFC6550: Advertising External Routes with Non-Storing
-      Mode Signaling.
+4.1.  Updates to RFC6550
+
+4.1.1.  Advertising External Routes with Non-Storing Mode Signaling.
 
    Section 6.7.8. of [RFC6550] introduces the 'E' flag that is set to
    indicate that the 6LR that generates the DAO redistributes external
@@ -388,10 +389,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-
-Robles, et al.           Expires March 25, 2021                 [Page 7]
+Robles, et al.            Expires July 10, 2021                 [Page 7]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    This specification updates [RFC6550] to RECOMMEND that external
@@ -428,6 +428,100 @@ Internet-Draft               RPL-data-plane               September 2020
    injected an external route MUST uncompress the packet before
    forwarding over that external route.
 
+4.1.2.  Configuration Options and Mode of Operation
+
+   Section 6.7.6 of RFC6550 describes the DODAG Configuration Option as
+   containing a series of Flags in the first octet of the payload.
+
+   Anticipating future work to revise RPL relating to how the LLN and
+   DODAG are configured, this document renames the DODAG Configuration
+   Option Flags registry so that it applies to Mode of Operation (MOP)
+   values zero (0) to six (6) only, leaving the flags unassigned for MOP
+   value seven (7).The MOP is described in RFC6550 section 6.3.1.
+
+   In addition, this document reserves MOP value 7 for future expansion.
+
+   See Sections 11.2 and 11.3.
+
+
+
+Robles, et al.            Expires July 10, 2021                 [Page 8]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
+4.1.3.  Indicating the new RPI in the DODAG Configuration option Flag.
+
+   In order to avoid a Flag Day caused by lack of interoperation between
+   new RPI Option Type (0x23) and old RPI Option Type (0x63) nodes, this
+   section defines a flag in the DIO Configuration option, to indicate
+   when the new RPI Option Type can be safely used.  This means, the
+   flag is going to indicate the value of Option Type that the network
+   will be using for the RPL Option.  Thus, when a node joins to a
+   network it will know which value to use.  With this, RPL-capable
+   nodes know if it is safe to use 0x23 when creating a new RPL Option.
+   A node that forwards a packet with an RPI MUST NOT modify the Option
+   Type of the RPL Option.
+
+   This is done using a DODAG Configuration option flag which will
+   signal "RPI 0x23 enable" and propagate through the network.
+   Section 6.3.1. of [RFC6550] defines a 3-bit Mode of Operation (MOP)
+   in the DIO Base Object.  The flag is defined only for MOP value
+   between 0 to 6.
+
+   For a MOP value of 7, a node MUST use the RPI 0x23 option.
+
+   As stated in [RFC6550] the DODAG Configuration option is present in
+   DIO messages.  The DODAG Configuration option distributes
+   configuration information.  It is generally static, and does not
+   change within the DODAG.  This information is configured at the DODAG
+   root and distributed throughout the DODAG with the DODAG
+   Configuration option.  Nodes other than the DODAG root do not modify
+   this information when propagating the DODAG Configuration option.
+
+   Currently, the DODAG Configuration option in [RFC6550] states: "the
+   unused bits MUST be initialized to zero by the sender and MUST be
+   ignored by the receiver".  If the flag is received with a value zero
+   (which is the default), then new nodes will remain in RFC6553
+   Compatible Mode; originating traffic with the old-RPI Option Type
+   (0x63) value.  If the flag is received with a value of 1, then the
+   value for the RPL Option MUST be set to 0x23.
+
+   Bit number three of the flag field in the DODAG Configuration option
+   is to be used as shown in Figure 2 (which is the same as Figure 39 in
+   Section 11 and is shown here for convenience):
+
+
+
+
+
+
+
+
+
+
+
+Robles, et al.            Expires July 10, 2021                 [Page 9]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
+                  +------------+-----------------+---------------+
+                  | Bit number |   Description   |   Reference   |
+                  +------------+-----------------+---------------+
+                  |      3     | RPI 0x23 enable | This document |
+                  +------------+-----------------+---------------+
+
+
+    Figure 2: DODAG Configuration option Flag to indicate the RPI-flag-
+                                   day.
+
+   In the case of reboot, the node (6LN or 6LR) does not remember the
+   RPI Option Type (i.e., whether or not the flag is set), so the node
+   will not trigger DIO messages until a DIO message is received
+   indicating the RPI value to be used.  The node will use the value
+   0x23 if the network supports this feature.
+
 4.2.  Updates to RFC6553: Indicating the new RPI Option Type.
 
    This modification is required in order to be able to send, for
@@ -435,20 +529,13 @@ Internet-Draft               RPL-data-plane               September 2020
    through Internet (see Section 7.2.1), without requiring IPv6-in-IPv6
    encapsulation.
 
-   [RFC6553] (Section 6, Page 7) states as shown in Figure 2, that in
+   [RFC6553] (Section 6, Page 7) states as shown in Figure 3, that in
    the Option Type field of the RPL Option, the two high order bits must
    be set to '01' and the third bit is equal to '1'.  The first two bits
    indicate that the IPv6 node must discard the packet if it doesn't
    recognize the Option Type, and the third bit indicates that the
    Option Data may change in route.  The remaining bits serve as the
    Option Type.
-
-
-
-Robles, et al.           Expires March 25, 2021                 [Page 8]
-
-Internet-Draft               RPL-data-plane               September 2020
-
 
    +-------+-------------------+----------------+-----------+
    |  Hex  |    Binary Value   |   Description  | Reference |
@@ -458,7 +545,7 @@ Internet-Draft               RPL-data-plane               September 2020
    |  0x63 |  01 |  1  | 00011 |   RPL Option   | [RFC6553] |
    +-------+-----+-----+-------+----------------+-----------+
 
-                   Figure 2: Option Type in RPL Option.
+                   Figure 3: Option Type in RPL Option.
 
    This document illustrates that it is not always possible to know for
    sure at the source that a packet will only travel within the RPL
@@ -467,6 +554,14 @@ Internet-Draft               RPL-data-plane               September 2020
    At the time [RFC6553] was published, leaking a Hop-by-Hop header in
    the outer IPv6 header chain could potentially impact core routers in
    the internet.  So at that time, it was decided to encapsulate any
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 10]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    packet with a RPL Option using IPv6-in-IPv6 in all cases where it was
    unclear whether the packet would remain within the RPL domain.  In
    the exception case where a packet would still leak, the Option Type
@@ -498,31 +593,31 @@ Internet-Draft               RPL-data-plane               September 2020
    the current value of the Option Type, if a node in the Internet is
    configured to process the Hop-by-Hop header, and if such node
    encounters an option with the first two bits set to 01 and conforms
-
-
-
-Robles, et al.           Expires March 25, 2021                 [Page 9]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    to [RFC8200], it will drop the packet.  Host systems should do the
    same, irrespective of the configuration.
 
    Thus, this document updates the Option Type of the RPL Option
-   [RFC6553], abusively naming it RPI Option Type for simplicity, to
-   (Figure 3): the two high order bits MUST be set to '00' and the third
-   bit is equal to '1'.  The first two bits indicate that the IPv6 node
-   MUST skip over this option and continue processing the header
-   ([RFC8200] Section 4.2) if it doesn't recognize the Option Type, and
-   the third bit continues to be set to indicate that the Option Data
-   may change en route.  The rightmost five bits remain at 0x3(00011).
-   This ensures that a packet that leaves the RPL domain of an LLN (or
-   that leaves the LLN entirely) will not be discarded when it contains
-   the RPL Option.
+   [RFC6553], naming it RPI Option Type for simplicity, to (Figure 4):
+   the two high order bits MUST be set to '00' and the third bit is
+   equal to '1'.  The first two bits indicate that the IPv6 node MUST
+   skip over this option and continue processing the header ([RFC8200]
+   Section 4.2) if it doesn't recognize the Option Type, and the third
+   bit continues to be set to indicate that the Option Data may change
+   en route.  The rightmost five bits remain at 0x3(00011).  This
+   ensures that a packet that leaves the RPL domain of an LLN (or that
+   leaves the LLN entirely) will not be discarded when it contains the
+   RPL Option.
 
    With the new Option Type, if an IPv6 (intermediate) node (RPL-not-
    capable) receives a packet with a RPL Option, it should ignore the
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 11]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    Hop-by-Hop RPL Option (skip over this option and continue processing
    the header).  This is relevant, as it was mentioned previously, in
    the case that there is a flow from RAL to Internet (see
@@ -538,7 +633,7 @@ Internet-Draft               RPL-data-plane               September 2020
    |  0x23 |  00 |  1  | 00011 |  RPL Option |[RFCXXXX](*)|
    +-------+-----+-----+-------+-------------+------------+
 
-      Figure 3: Revised Option Type in RPL Option. (*)represents this
+      Figure 4: Revised Option Type in RPL Option. (*)represents this
                                  document
 
    Without the signaling described below, this change would otherwise
@@ -554,21 +649,13 @@ Internet-Draft               RPL-data-plane               September 2020
    the network to be incrementally upgraded and allows the DODAG root to
    know which parts of the network have been upgraded.
 
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 10]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    When originating new packets, implementations SHOULD have an option
    to determine which value to originate with, this option is controlled
    by the DIO option described below.
 
    The change of RPI Option Type from 0x63 to 0x23, makes all [RFC8200]
    Section 4.2 compliant nodes tolerant of the RPL artifacts.  There is
-   therefore no longer a necessity to remove the artifacts when sending
+   therefore no longer a need to remove the artifacts when sending
    traffic to the Internet.  This change clarifies when to use IPv6-in-
    IPv6 headers, and how to address them: The Hop-by-Hop Options header
    containing the RPI MUST always be added when 6LRs originate packets
@@ -577,6 +664,15 @@ Internet-Draft               RPL-data-plane               September 2020
    Options header containing the RPL Option.  The IPv6-in-IPv6 header is
    to be addressed to the RPL root when on the way up, and to the end-
    host when on the way down.
+
+
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 12]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
 
    In the non-storing case, dealing with not-RPL aware leaf nodes is
    much easier as the 6LBR (DODAG root) has complete knowledge about the
@@ -590,107 +686,9 @@ Internet-Draft               RPL-data-plane               September 2020
    The non-storing mode case does not require the type change from 0x63
    to 0x23, as the root can always create the right packet.  The type
    change does not adversely affect the non-storing case.(see
-   Section 4.4)
+   Section 4.1.3)
 
-4.3.  Updates to RFC6550: Configuration Options and Mode of Operation
-
-   RFC6550 section 6.7.6 describes the DODAG Configuration Option.  In
-   this option are a series of Flags in the first octet of the payload.
-   These flags are described by the DODAG Configuration Option Flags
-   registry [dodagcfg], in section 20.14 of RFC6550.
-
-   Anticipating future work to revise RPL relating to how the LLN and
-   DODAG is configured, this document changes the interpretation of the
-   [dodagcfg] Registry to be limited to Mode-of-Operation (MOP)
-   specific.  The MOP is described in [RFC6550] section 6.3.1.  The
-   Options Flags Registry is renamed, and applies to MOP values zero (0)
-   to six (6) only, leaving the flags reserved for MOP value seven (7).
-
-   In addition, this document reserves MOP value 7 for future expansion.
-
-
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 11]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
-4.4.  Updates to RFC6550: Indicating the new RPI in the DODAG
-      Configuration option Flag.
-
-   In order to avoid a Flag Day caused by lack of interoperation between
-   new RPI Option Type (0x23) and old RPI Option Type (0x63) nodes, this
-   section defines a flag in the DIO Configuration option, to indicate
-   when the new RPI Option Type can be safely used.  This means, the
-   flag is going to indicate the value of Option Type that the network
-   will be using for the RPL Option.  Thus, when a node joins to a
-   network will know which value to use.  With this, RPL-capable nodes
-   know if it is safe to use 0x23 when creating a new RPL Option.  A
-   node that forwards a packet with an RPI MUST NOT modify the Option
-   Type of the RPL Option.
-
-   This is done using a DODAG Configuration option flag which will
-   signal "RPI 0x23 enable" and propagate through the network.
-   Section 6.3.1. of [RFC6550] defines a 3-bit Mode of Operation (MOP)
-   in the DIO Base Object.  The flag is defined only for MOP value
-   between 0 to 6.
-
-   For a MOP value of 7 or above, the flag MAY indicate something
-   different and MUST NOT be interpreted as "RPI 0x23 enable" unless the
-   specification of the MOP indicates to do so.  For a MOP value of 7, a
-   node SHOULD assume that the RPI 0x23 option is enabled.
-
-   As stated in [RFC6550] the DODAG Configuration option is present in
-   DIO messages.  The DODAG Configuration option distributes
-   configuration information.  It is generally static, and does not
-   change within the DODAG.  This information is configured at the DODAG
-   root and distributed throughout the DODAG with the DODAG
-   Configuration option.  Nodes other than the DODAG root do not modify
-   this information when propagating the DODAG Configuration option.
-
-   Currently, the DODAG Configuration option in [RFC6550] states: "the
-   unused bits MUST be initialize to zero by the sender and MUST be
-   ignored by the receiver".  If the flag is received with a value zero
-   (which is the default), then new nodes will remain in RFC6553
-   Compatible Mode; originating traffic with the old-RPI Option Type
-   (0x63) value.  If the flag is received with a value of 1, then the
-   value for the RPL Option MUST be set to 0x23.
-
-   Bit number three of the flag field in the DODAG Configuration option
-   is to be used as shown in Figure 4 (which is the same as Figure 39 in
-   Section 11 and is shown here for convenience):
-
-
-
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 12]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
-                +------------+-----------------+---------------+
-                | Bit number |   Description   |   Reference   |
-                +------------+-----------------+---------------+
-                |      3     | RPI 0x23 enable | This document |
-                +------------+-----------------+---------------+
-
-
-    Figure 4: DODAG Configuration option Flag to indicate the RPI-flag-
-                                   day.
-
-   In the case of reboot, the node (6LN or 6LR) does not remember the
-   RPI Option Type (i.e., whether or not the flag is set), so the node
-   will not trigger DIO messages until a DIO message is received
-   indicating the RPI value to be used.  The node will use the value
-   0x23 if the network supports this feature.
-
-4.5.  Updates to RFC8138: Indicating the way to decompress with the new
+4.3.  Updates to RFC8138: Indicating the way to decompress with the new
       RPI Option Type.
 
    This modification is required in order to be able to decompress the
@@ -701,8 +699,9 @@ Internet-Draft               RPL-data-plane               September 2020
    decompress using the RPI Option Type that is currently active: that
    is, a choice between 0x23 (new) and 0x63 (old).  The node will know
    which to use based upon the presence of the flag in the DODAG
-   Configuration option defined in Section 4.4.  E.g.  If the network is
-   in 0x23 mode (by DIO option), then it should be decompressed to 0x23.
+   Configuration option defined in Section 4.1.3.  E.g.  If the network
+   is in 0x23 mode (by DIO option), then it should be decompressed to
+   0x23.
 
    [RFC8138] section 7 documents how to compress the IPv6-in-IPv6
    header.
@@ -725,9 +724,10 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 13]
+
+Robles, et al.            Expires July 10, 2021                [Page 13]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-+ ... -+-+ ... +-+- ... -+-+- +-+-+-+ ... +-+-+ ... -+++ ... +-...
@@ -781,9 +781,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 14]
+Robles, et al.            Expires July 10, 2021                [Page 14]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
                      +------------+
@@ -837,9 +837,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 15]
+Robles, et al.            Expires July 10, 2021                [Page 15]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 6.  Use cases
@@ -854,7 +854,7 @@ Internet-Draft               RPL-data-plane               September 2020
    Section 7.1.4) - Inside of the LLN when the final destination address
    resides outside of the LLN (e.g. see Section 7.2.3).
 
-   The uses cases are as follows:
+   The use cases are as follows:
 
    Interaction between Leaf and Root:
 
@@ -893,9 +893,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 16]
+Robles, et al.            Expires July 10, 2021                [Page 16]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    As the rank information in the RPI artifact is changed at each hop,
@@ -931,9 +931,10 @@ Internet-Draft               RPL-data-plane               September 2020
    exception to this rule and removing the RPI for downward flows in
    non-storing mode.  This exception covered a very small number of
    cases, and caused significant interoperability challenges while
-   adding significant in the code and tests.  The ability to compress
-   the RPI down to three bytes or less removes much of the pressure to
-   optimize this any further [I-D.ietf-anima-autonomic-control-plane].
+   adding significant interest in the code and tests.  The ability to
+   compress the RPI down to three bytes or less removes much of the
+   pressure to optimize this any further
+   [I-D.ietf-anima-autonomic-control-plane].
 
    Throughout the following subsections, the examples are described in
    more details in the first subsections, and more concisely in the
@@ -944,15 +945,17 @@ Internet-Draft               RPL-data-plane               September 2020
 
       The RPI has to be in every packet that traverses the LLN.
 
+
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 17]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
       - Because of the above requirement, packets from the Internet have
       to be encapsulated.
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 17]
-
-Internet-Draft               RPL-data-plane               September 2020
-
 
       - A Header cannot be inserted or removed on the fly inside an IPv6
       packet that is being routed.
@@ -986,11 +989,13 @@ Internet-Draft               RPL-data-plane               September 2020
       - In the uses cases, we assume that the RAL supports IP-in-IP
       encapsulation.
 
-      - In the uses cases, we dont assume that the RUL supports IP-in-IP
-      encapsulation.
+      - In the uses cases, we don't assume that the RUL supports IP-in-
+      IP encapsulation.
 
       - For traffic leaving a RUL, if the RUL adds an opaque RPI then
-      the description of the RAL applies.
+      the description of the RAL applies.  The 6LR as a RPL border
+      router SHOULD rewrite the RPI to indicate the selected Instance
+      and set the flags.
 
       - The description for RALs applies to RAN in general.
 
@@ -998,17 +1003,14 @@ Internet-Draft               RPL-data-plane               September 2020
 
       - Compression is based on [RFC8138].
 
-      - The flow label [RFC6437] is not needed in RPL.
 
 
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 18]
+Robles, et al.            Expires July 10, 2021                [Page 18]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
+
+      - The flow label [RFC6437] is not needed in RPL.
 
 7.  Storing mode
 
@@ -1059,11 +1061,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-
-
-Robles, et al.           Expires March 25, 2021                [Page 19]
+Robles, et al.            Expires July 10, 2021                [Page 19]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +---------------------+--------------+------------+----------------+
@@ -1117,9 +1117,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 20]
+Robles, et al.            Expires July 10, 2021                [Page 20]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 7.1.1.  SM: Example of Flow from RAL to Root
@@ -1173,9 +1173,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 21]
+Robles, et al.            Expires July 10, 2021                [Page 21]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 7.1.2.  SM: Example of Flow from Root to RAL
@@ -1229,9 +1229,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 22]
+Robles, et al.            Expires July 10, 2021                [Page 22]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    number of routers (6LR) that the packet goes through from the 6LBR
@@ -1263,7 +1263,7 @@ Internet-Draft               RPL-data-plane               September 2020
 
        Figure 10: SM: Summary of the use of headers from root to RUL
 
-   IP-in-IP encapsulation MAY be avoided for Root to RUL communication.
+   IP-in-IP encapsulation may be avoided for Root to RUL communication.
    In SM, it can be replaced by a loose RH3 header that indicates the
    RUL, in which case the packet is routed to the 6LR as a normal SM
    operation, then the 6LR forwards to the RUL based on the RH3, and the
@@ -1285,9 +1285,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 23]
+Robles, et al.            Expires July 10, 2021                [Page 23]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -1341,9 +1341,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 24]
+Robles, et al.            Expires July 10, 2021                [Page 24]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
   +-----------+------+--------------+----------------+-----------------+
@@ -1397,9 +1397,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 25]
+Robles, et al.            Expires July 10, 2021                [Page 25]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    RPL information from RFC 6553 may go out to Internet as it will be
@@ -1453,9 +1453,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 26]
+Robles, et al.            Expires July 10, 2021                [Page 26]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1509,9 +1509,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 27]
+Robles, et al.            Expires July 10, 2021                [Page 27]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1565,9 +1565,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 28]
+Robles, et al.            Expires July 10, 2021                [Page 28]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +---------+-------+------------+-------------+-------------+--------+
@@ -1621,9 +1621,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 29]
+Robles, et al.            Expires July 10, 2021                [Page 29]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +---------+-------+------------+--------------+-------------+-------+
@@ -1677,9 +1677,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 30]
+Robles, et al.            Expires July 10, 2021                [Page 30]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    For example, a communication flow could be: Node F (RAL src)--> Node
@@ -1733,9 +1733,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 31]
+Robles, et al.            Expires July 10, 2021                [Page 31]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    RAL src (6LN) --> 6LR_ia --> common parent (6LBR - The root-) -->
@@ -1789,9 +1789,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 32]
+Robles, et al.            Expires July 10, 2021                [Page 32]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 7.3.3.  SM: Example of Flow from RUL to RAL
@@ -1845,9 +1845,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 33]
+Robles, et al.            Expires July 10, 2021                [Page 33]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
   +-----------+------+---------+---------+---------+---------+---------+
@@ -1901,9 +1901,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 34]
+Robles, et al.            Expires July 10, 2021                [Page 34]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    the RPI (RPI1) and inserts a new RPI (RPI2) addressed to the 6LR
@@ -1957,9 +1957,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 35]
+Robles, et al.            Expires July 10, 2021                [Page 35]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    The leaf can be a router 6LR or a host, both indicated as 6LN
@@ -2013,9 +2013,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 36]
+Robles, et al.            Expires July 10, 2021                [Page 36]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 8.1.  Non-Storing Mode: Interaction between Leaf and Root
@@ -2069,9 +2069,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 37]
+Robles, et al.            Expires July 10, 2021                [Page 37]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
                     +-----------+-----+-------+------+
@@ -2125,9 +2125,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 38]
+Robles, et al.            Expires July 10, 2021                [Page 38]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+----------+----------+
@@ -2181,9 +2181,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 39]
+Robles, et al.            Expires July 10, 2021                [Page 39]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -2237,9 +2237,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 40]
+Robles, et al.            Expires July 10, 2021                [Page 40]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
   +---------+----+-----------------+-----------------+-----------------+
@@ -2283,8 +2283,8 @@ Internet-Draft               RPL-data-plane               September 2020
 
    For example, a communication flow could be: Node F (RAL) --> Node D
    --> Node B --> Node A --> Internet.  Having the RAL information about
-   the RPL domain, it may encapsulate to the root when the destination
-   is not in the RPL domain of the RAL.
+   the RPL domain, the packet may be encapsulated to the root when the
+   destination is not in the RPL domain of the RAL.
 
    6LR_i represents the intermediate routers from source to destination,
    1 <= i <= n, where n is the total number of routers (6LR) that the
@@ -2293,9 +2293,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 41]
+Robles, et al.            Expires July 10, 2021                [Page 41]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    In this case, the encapsulation from the RAL to the root is optional.
@@ -2349,9 +2349,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 42]
+Robles, et al.            Expires July 10, 2021                [Page 42]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+--------------+--------------+--------------+----------+
@@ -2405,9 +2405,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 43]
+Robles, et al.            Expires July 10, 2021                [Page 43]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -2461,9 +2461,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 44]
+Robles, et al.            Expires July 10, 2021                [Page 44]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +---------+----+-------------+--------------+--------------+--------+
@@ -2517,9 +2517,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 45]
+Robles, et al.            Expires July 10, 2021                [Page 45]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
   +----------+--------+------------------+-----------+-----------+-----+
@@ -2573,9 +2573,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 46]
+Robles, et al.            Expires July 10, 2021                [Page 46]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    6LR_id represents the intermediate routers from the root to the
@@ -2629,9 +2629,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 47]
+Robles, et al.            Expires July 10, 2021                [Page 47]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +---------+-------+----------+------------+----------+------------+
@@ -2685,9 +2685,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 48]
+Robles, et al.            Expires July 10, 2021                [Page 48]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 8.3.2.  Non-SM: Example of Flow from RAL to RUL
@@ -2741,9 +2741,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 49]
+Robles, et al.            Expires July 10, 2021                [Page 49]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
   +-----------+---------+---------+---------+---------+---------+------+
@@ -2797,9 +2797,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 50]
+Robles, et al.            Expires July 10, 2021                [Page 50]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 8.3.3.  Non-SM: Example of Flow from RUL to RAL
@@ -2853,9 +2853,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 51]
+Robles, et al.            Expires July 10, 2021                [Page 51]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 8.3.4.  Non-SM: Example of Flow from RUL to RUL
@@ -2909,9 +2909,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 52]
+Robles, et al.            Expires July 10, 2021                [Page 52]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 9.  Operational Considerations of supporting RUL-leaves
@@ -2945,7 +2945,7 @@ Internet-Draft               RPL-data-plane               September 2020
    the leaf.  For example, in Figure 6, Node E is the 6LR prior to leaf
    Node G, or Node C is the 6LR prior to leaf Node J.
 
-   traffic originating from the RPL root (such as when the data
+   Traffic originating from the RPL root (such as when the data
    collection system is co-located on the RPL root), does not require an
    IPv6-in-IPv6 header (in storing or non-storing mode), as the packet
    is originating at the root, and the root can insert the RPI and RH3
@@ -2965,9 +2965,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 53]
+Robles, et al.            Expires July 10, 2021                [Page 53]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
 10.  Operational considerations of introducing 0x23
@@ -3021,9 +3021,9 @@ Internet-Draft               RPL-data-plane               September 2020
 
 
 
-Robles, et al.           Expires March 25, 2021                [Page 54]
+Robles, et al.            Expires July 10, 2021                [Page 54]
 
-Internet-Draft               RPL-data-plane               September 2020
+Internet-Draft               RPL-data-plane                 January 2020
 
 
    +-------+-------------------+------------------------+---------- -+
@@ -3052,16 +3052,20 @@ Internet-Draft               RPL-data-plane               September 2020
    Figure 39: DODAG Configuration option Flag to indicate the RPI-flag-
                                    day.
 
-11.2.  Changes to DODAG Configuration Options Flags
+11.2.  Change to the DODAG Configuration Options Flags registry
 
-   This document changes the name of the "DODAG Configuration Option
-   Flags" [dodagcfg] to "DODAG Configuration Option Flags for MOP 0..6".
+   This document requests IANA to change the name of the "DODAG
+   Configuration Option Flags" registry to "DODAG Configuration Option
+   Flags for MOP 0..6".
 
 11.3.  Change MOP value 7 to Reserved
 
-   This document changes the allocation status of the Mode of Operation
-   (MOP) [ianamop] from Unassigned to Reserved.  This change is in
-   support of future work related to capabilities.
+   This document requests the changing the registration status of value
+   7 in the Mode of Operation registry from Unassigned to Reserved.
+   This change is in support of future work.
+
+   This document requests to be mentioned as a reference for this entry
+   in the registry.
 
 12.  Security Considerations
 
@@ -3070,22 +3074,22 @@ Internet-Draft               RPL-data-plane               September 2020
 
    The IPv6-in-IPv6 mechanism described in this document is much more
    limited than the general mechanism described in [RFC2473].  The
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 55]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    willingness of each node in the LLN to decapsulate packets and
    forward them could be exploited by nodes to disguise the origin of an
    attack.
 
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 55]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    While a typical LLN may be a very poor origin for attack traffic (as
    the networks tend to be very slow, and the nodes often have very low
    duty cycles), given enough nodes, LLNs could still have a significant
-   impact, particularly if attack is targeting another LLN.
+   impact, particularly if the attack is targeting another LLN.
    Additionally, some uses of RPL involve large backbone ISP scale
    equipment [I-D.ietf-anima-autonomic-control-plane], which may be
    equipped with multiple 100Gb/s interfaces.
@@ -3126,18 +3130,17 @@ Internet-Draft               RPL-data-plane               September 2020
    to "Use IPsec".  Use of ESP would prevent [RFC8138] compression
    (compression must occur before encryption), and [RFC8138] compression
    is lossy in a way that prevents use of AH.  These are minor issues.
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 56]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    The major issue is how to establish trust enough such that IKEv2
    could be used.  This would require a system of certificates to be
    present in every single node, including any Internet nodes that might
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 56]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    need to communicate with the LLN.  Thus, using IPsec requires a
    global PKI in the general case.
 
@@ -3176,28 +3179,40 @@ Internet-Draft               RPL-data-plane               September 2020
    inserted in a non-storing network on traffic that is leaving the LLN,
    but this document should not preclude such a future innovation.  It
    should just be noted that an incoming RH3 must be fully consumed, or
-   very carefully inspected.
+   very carefully inspected to match a policy that applies to this
+   network and is correctly processed by the leaves.
 
    The RPI, if permitted to enter the LLN, could be used by an attacker
    to change the priority of a packet by selecting a different
    RPLInstanceID, perhaps one with a higher energy cost, for instance.
    It could also be that not all nodes are reachable in an LLN using the
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 57]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    default RPLInstanceID, but a change of RPLInstanceID would permit an
    attacker to bypass such filtering.  Like the RH3, an RPI is to be
    inserted by the RPL root on traffic entering the LLN by first
    inserting an IPv6-in-IPv6 header.  The attacker's RPI therefore will
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 57]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    not be seen by the network.  Upon reaching the destination node the
    RPI has no further meaning and is just skipped; the presence of a
    second RPI will have no meaning to the end node as the packet has
    already been identified as being at it's final destination.
+
+   For traffic leaving a RUL, if the RUL adds an opaque RPI then the
+   description of the RAL applies.  The 6LR as a RPL border router
+   SHOULD rewrite the RPI to indicate the selected Instance and set the
+   flags.  This is done in order to avoid: 1) The leaf is an external
+   router that passes a packet that it did not generate and that carries
+   an unrelated RPI and 2) The leaf is an attacker or presents
+   misconfiguration and tries to inject traffic in a protected instance.
+   Also, this applies in the case where the leaf is aware of the RPL
+   instance and passes a correct RPI, the 6LR needs a configuration that
+   allows that leaf to inject in that instance.
 
    The RH3 and RPIs could be abused by an attacker inside of the network
    to route packets on non-obvious ways, perhaps eluding observation.
@@ -3227,6 +3242,14 @@ Internet-Draft               RPL-data-plane               September 2020
    the LLN.  That is, an RH3 with a CmprI less than 8 , should be
    considered an attack (see RFC6554, section 3).
 
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 58]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    Nodes outside of the LLN will need to pass IPv6-in-IPv6 traffic
    through the RPL root to perform this attack.  To counter, the RPL
    root SHOULD either restrict ingress of IPv6-in-IPv6 packets (the
@@ -3241,15 +3264,6 @@ Internet-Draft               RPL-data-plane               September 2020
    [I-D.ietf-6lo-backbone-router].  In this case the BCP38 filtering
    needs to take this into account, either by exchanging detailed
    routing information on each LLN, or by moving the BCP38 filtering
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 58]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    further towards the Internet, so that the details of the multiple
    LLNs do not matter.
 
@@ -3279,32 +3293,22 @@ Internet-Draft               RPL-data-plane               September 2020
               Address Spoofing", BCP 38, RFC 2827, DOI 10.17487/RFC2827,
               May 2000, <https://www.rfc-editor.org/info/bcp38>.
 
-   [dodagcfg]
-              IANA, "DODAG Configuration Option Flags", Sept 2020,
-              <https://www.iana.org/assignments/rpl/rpl.xhtml#dodag-
-              config-option-flags>.
-
-   [ianamop]  IANA, "Mode Of Operation", Sept 2020,
-              <https://www.iana.org/assignments/rpl/rpl.xhtml#mop>.
-
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 59]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    [RFC6040]  Briscoe, B., "Tunnelling of Explicit Congestion
               Notification", RFC 6040, DOI 10.17487/RFC6040, November
               2010, <https://www.rfc-editor.org/info/rfc6040>.
-
-
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 59]
-
-Internet-Draft               RPL-data-plane               September 2020
-
 
    [RFC6282]  Hui, J., Ed. and P. Thubert, "Compression Format for IPv6
               Datagrams over IEEE 802.15.4-Based Networks", RFC 6282,
@@ -3349,22 +3353,19 @@ Internet-Draft               RPL-data-plane               September 2020
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
+
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 60]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    [RFC8200]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
               (IPv6) Specification", STD 86, RFC 8200,
               DOI 10.17487/RFC8200, July 2017,
               <https://www.rfc-editor.org/info/rfc8200>.
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 60]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
-   [RFC8504]  Chown, T., Loughney, J., and T. Winters, "IPv6 Node
-              Requirements", BCP 220, RFC 8504, DOI 10.17487/RFC8504,
-              January 2019, <https://www.rfc-editor.org/info/rfc8504>.
 
 14.2.  Informative References
 
@@ -3393,30 +3394,34 @@ Internet-Draft               RPL-data-plane               September 2020
    [I-D.ietf-anima-autonomic-control-plane]
               Eckert, T., Behringer, M., and S. Bjarnason, "An Autonomic
               Control Plane (ACP)", draft-ietf-anima-autonomic-control-
-              plane-29 (work in progress), September 2020.
+              plane-30 (work in progress), October 2020.
 
    [I-D.ietf-anima-bootstrapping-keyinfra]
               Pritikin, M., Richardson, M., Eckert, T., Behringer, M.,
               and K. Watsen, "Bootstrapping Remote Secure Key
               Infrastructures (BRSKI)", draft-ietf-anima-bootstrapping-
-              keyinfra-43 (work in progress), August 2020.
+              keyinfra-45 (work in progress), November 2020.
 
    [I-D.ietf-intarea-tunnels]
               Touch, J. and M. Townsley, "IP Tunnels in the Internet
               Architecture", draft-ietf-intarea-tunnels-10 (work in
               progress), September 2019.
 
+
+
+
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 61]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    [I-D.ietf-roll-unaware-leaves]
               Thubert, P. and M. Richardson, "Routing for RPL Leaves",
-              draft-ietf-roll-unaware-leaves-19 (work in progress),
-              September 2020.
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 61]
-
-Internet-Draft               RPL-data-plane               September 2020
-
+              draft-ietf-roll-unaware-leaves-28 (work in progress),
+              December 2020.
 
    [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
               (IPv6) Specification", RFC 2460, DOI 10.17487/RFC2460,
@@ -3457,27 +3462,32 @@ Internet-Draft               RPL-data-plane               September 2020
               Lossy Networks", RFC 7102, DOI 10.17487/RFC7102, January
               2014, <https://www.rfc-editor.org/info/rfc7102>.
 
+
+
+
+
+
+
+
+Robles, et al.            Expires July 10, 2021                [Page 62]
+
+Internet-Draft               RPL-data-plane                 January 2020
+
+
    [RFC7416]  Tsao, T., Alexander, R., Dohler, M., Daza, V., Lozano, A.,
               and M. Richardson, Ed., "A Security Threat Analysis for
               the Routing Protocol for Low-Power and Lossy Networks
               (RPLs)", RFC 7416, DOI 10.17487/RFC7416, January 2015,
               <https://www.rfc-editor.org/info/rfc7416>.
 
-
-
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 62]
-
-Internet-Draft               RPL-data-plane               September 2020
-
-
    [RFC8180]  Vilajosana, X., Ed., Pister, K., and T. Watteyne, "Minimal
               IPv6 over the TSCH Mode of IEEE 802.15.4e (6TiSCH)
               Configuration", BCP 210, RFC 8180, DOI 10.17487/RFC8180,
               May 2017, <https://www.rfc-editor.org/info/rfc8180>.
+
+   [RFC8504]  Chown, T., Loughney, J., and T. Winters, "IPv6 Node
+              Requirements", BCP 220, RFC 8504, DOI 10.17487/RFC8504,
+              January 2019, <https://www.rfc-editor.org/info/rfc8504>.
 
    [RFC8505]  Thubert, P., Ed., Nordmark, E., Chakrabarti, S., and C.
               Perkins, "Registration Extensions for IPv6 over Low-Power
@@ -3515,14 +3525,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-Robles, et al.           Expires March 25, 2021                [Page 63]
+Robles, et al.            Expires July 10, 2021                [Page 63]

--- a/roll-useofrplinfo.xml
+++ b/roll-useofrplinfo.xml
@@ -216,6 +216,11 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina / Aalto University, Finland
         Terminology defined in <xref target="RFC7102"/> applies to this document: LLN, RPL, RPL domain and ROLL.
         </t>
         <t>
+        Consumed: A Routing Header is consumed when the Segments Left field is zero, which indicates that the
+        destination in the IPv6 header is the final destination of the packet and that the hops in the Routing Header
+        have been traversed.
+        </t>
+        <t>
         RPL Leaf: An IPv6 host that is attached to a RPL router and obtains connectivity
         through a RPL Destination Oriented Directed Acyclic Graph (DODAG). As an IPv6 node,
         a RPL Leaf is expected to ignore a consumed Routing Header and as an IPv6 host, it
@@ -2914,8 +2919,8 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina / Aalto University, Finland
             is in support of future work.
           </t>
 	  <t>
-            This document requests to be mentioned as a reference for this entry in 
-	    the registry. 
+            This document requests to be mentioned as a reference for this entry in
+	    the registry.
           </t>
         </section>
       </section>
@@ -3034,7 +3039,9 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina / Aalto University, Finland
             where an RH3 is inserted in a non-storing network on traffic that
             is leaving the LLN, but this document should not preclude such a
             future innovation.  It should just be noted that an incoming RH3
-            must be fully consumed, or very carefully inspected.
+            must be fully consumed, or very carefully inspected to match a
+            policy that applies to this network and is correctly processed by
+            the leaves.
           </t>
           <t>
             The RPI, if permitted to enter the LLN, could be used by


### PR DESCRIPTION
…S and COMMENT)

On December 18, 2020 at 10:42:24 AM, Pascal Thubert (pthubert) (pthubert=40cisco.com@dmarc.ietf.org) wrote:
Hello Michael and all:

> -----Original Message-----
> From: Roll <roll-bounces@ietf.org> On Behalf Of Michael Richardson
> Sent: mercredi 16 décembre 2020 19:02
> To: Erik Kline <ek.ietf@gmail.com>; Routing Over Low power and Lossy
> networks <roll@ietf.org>
> Subject: Re: [Roll] Erik Kline's Discuss on draft-ietf-roll-useofrplinfo-42: (with
> DISCUSS and COMMENT)
>
>
> Erik Kline via Datatracker <noreply@ietf.org> wrote:
> > I might recommend instead referring to RFC 6554 S4.2 for how to
> > handle RH3's if the node is also a RPL-aware router and say it MUST
> > drop the packet if segments left is non-zero and it's not a RPL-aware
> > router.
>
> > Related: I'd also recommend:
>
> > "It should just be noted that an incoming RH3 must be fully consumed,
> > or very carefully inspected."
>
> ->
>
> > "It should just be noted that an incoming RH3 MUST be fully
> > consumed."
>
> I think that Pascal and I, when we write the "carefully inspected", is that we
> are imagining situations where the topology is a bit subtle.

Yes, I expected policies that would validate the right of a Leaf to participate to a DODAG ,or to remap the information from the leaf (could be the RPI, the opaque field in the EARO, or the 6-tuple) into an RPI.

> Perhaps there are firewalls involved.
> Perhaps a device has multiple interfaces (many radios for instance) and the
> extra segments address the other interfaces.
>
> Also draft-ietf-anima-autonomic-control-plane uses storing mode, so never
> has
> RH3 headers, but imagine if it did.
>
> One could have a situation where the physical system containing one or more
> layers of container was not the ultimate last hop from a logical point of view.
> Rather than inner container was. So, it's all the same stack actually. In that
> case, an optimization might be to process more than one segment in that
> stack.
> (The ANIMA ACP definitely supports having VMs and containers inside
> routers)
>
> So, I can live with your suggestion, because in my case above, we can argue
> that it's still "consumed"
>
> > * I'm confused by the use of "consumed" here. Is the final RH3 entry
> > RUL's address? I guess you could say RH penultimate hop "consumes" the
> > header because the ultimate destination address is put in the header DA
> > field. Seems a bit odd though.
>
> Yes, that's what we mean.

Yes, as I said in my response I thought it was quite common. I'm surprised to find little art to quote.

> Once that ultimate destination is in the DA, then the RH3 is a dummy, but one
> we are aren't supposed to remove.
>
> > I assume 6LR_n gets RUL's address from the last segment in RH3.
>
> > "Consumed" means segments left == 0, I guess? I suppose should have
> > picked up on this terminology when it was first used in Section 2.
> > Maybe clarify what it means in that section (2)?
>
> Yes.

Cool, we're good!

Pascal
_______________________________________________
Roll mailing list
Roll@ietf.org
https://www.ietf.org/mailman/listinfo/roll
_______________________________________________
Roll mailing list
Roll@ietf.org
https://www.ietf.org/mailman/listinfo/roll