### PR TITLE
Subject: Re: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrp…

### DIFF
--- a/draft-ietf-roll-useofrplinfo-43.txt
+++ b/draft-ietf-roll-useofrplinfo-43.txt
@@ -6,9 +6,9 @@ ROLL Working Group                                             M. Robles
 Internet-Draft                                             UTN-FRM/Aalto
 Updates: 6553, 6550, 8138 (if approved)                    M. Richardson
 Intended status: Standards Track                                     SSW
-Expires: July 11, 2021                                        P. Thubert
+Expires: July 12, 2021                                        P. Thubert
                                                                    Cisco
-                                                         January 7, 2020
+                                                         January 8, 2021
 
 
 Using RPI Option Type, Routing Header for Source Routes and IPv6-in-IPv6
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 11, 2021.
+   This Internet-Draft will expire on July 12, 2021.
 
 
 
@@ -53,14 +53,14 @@ Status of This Memo
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 1]
+Robles, et al.            Expires July 12, 2021                 [Page 1]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 Copyright Notice
 
-   Copyright (c) 2020 IETF Trust and the persons identified as the
+   Copyright (c) 2021 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 2]
+Robles, et al.            Expires July 12, 2021                 [Page 2]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
        7.3.3.  SM: Example of Flow from RUL to RAL . . . . . . . . .  33
@@ -165,9 +165,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 3]
+Robles, et al.            Expires July 12, 2021                 [Page 3]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    traffic at all which is mostly Hop-by-Hop traffic (one exception
@@ -196,11 +196,11 @@ Internet-Draft               RPL-data-plane                 January 2020
 
    Most of the use cases described herein require the use of IPv6-in-
    IPv6 packet encapsulation.  When encapsulating and decapsulating
-   packets, RFC 6040 [RFC6040] MUST be applied to map the setting of the
-   explicit congestion notification (ECN) field between inner and outer
-   headers.  Additionally, [I-D.ietf-intarea-tunnels] is recommended
-   reading to explain the relationship of IP tunnels to existing
-   protocol layers and the challenges in supporting IP tunneling.
+   packets, [RFC6040] MUST be applied to map the setting of the explicit
+   congestion notification (ECN) field between inner and outer headers.
+   Additionally, [I-D.ietf-intarea-tunnels] is recommended reading to
+   explain the relationship of IP tunnels to existing protocol layers
+   and the challenges in supporting IP tunneling.
 
    Non-constrained uses of RPL are not in scope of this document, and
    applicability statements for those uses may provide different advice,
@@ -221,9 +221,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 4]
+Robles, et al.            Expires July 12, 2021                 [Page 4]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 2.  Terminology and Requirements Language
@@ -252,10 +252,12 @@ Internet-Draft               RPL-data-plane                 January 2020
    encapsulation.  For simplification, this document uses the standalone
    term leaf to mean a RPL leaf.
 
-   RPL Packet Information (RPI): The abstract information that [RFC6550]
-   places in IP packets.  The term is commonly used, including in this
-   document, to refer to the RPL Option [RFC6553] that transports that
-   abstract information in an IPv6 Hop-by-Hop Header.
+   RPL Packet Information (RPI): The information defined abstractly in
+   [RFC6550] to be placed in IP packets.  The term is commonly used,
+   including in this document, to refer to the RPL Option [RFC6553] that
+   transports that abstract information in an IPv6 Hop-by-Hop Header.
+   [RFC8138] provides an alternate (more compressed) formating for the
+   same abstract information.
 
    RPL-aware-node (RAN): A device which implements RPL.  Please note
    that the device can be found inside the LLN or outside LLN.
@@ -275,11 +277,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-
-
-Robles, et al.            Expires July 11, 2021                 [Page 5]
+Robles, et al.            Expires July 12, 2021                 [Page 5]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    6LoWPAN Router (6LR): [RFC6775] defines it as:" An intermediate
@@ -299,7 +299,7 @@ Internet-Draft               RPL-data-plane                 January 2020
    Flag Day: It is a mechanism for resolving an interoperability
    situation (e.g. lack of interoperation between new RPI Option Type
    (0x23) and old RPI Option Type (0x63) nodes) by making an abrupt,
-   planned changeover from one to the other.
+   disruptive changeover from one to the other.
 
    Non-Storing Mode (Non-SM): RPL mode of operation in which the RPL-
    aware-nodes send information to the root about their parents.  Thus,
@@ -333,9 +333,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 6]
+Robles, et al.            Expires July 12, 2021                 [Page 6]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +--------------+
@@ -360,14 +360,14 @@ Internet-Draft               RPL-data-plane                 January 2020
 
                            Figure 1: RPL Stack.
 
-   RPL supports two modes of Downward traffic: in storing mode (SM), it
-   is fully stateful; in non-storing mode (Non-SM), it is fully source
-   routed.  A RPL Instance is either fully storing or fully non-storing,
-   i.e. a RPL Instance with a combination of a fully storing and non-
-   storing nodes is not supported with the current specifications at the
-   time of writing this document.  Notice that external routes are
-   advertised (Upwards traffic) with non-storing-mode messaging even in
-   a storing-mode network.
+   RPL supports two modes of Downward internal traffic: in storing mode
+   (SM), it is fully stateful; in non-storing mode (Non-SM), it is fully
+   source routed.  A RPL Instance is either fully storing or fully non-
+   storing, i.e. a RPL Instance with a combination of a fully storing
+   and non-storing nodes is not supported with the current
+   specifications at the time of writing this document.  External routes
+   are advertised with non-storing-mode messaging even in a storing mode
+   network, see Section 4.1.1
 
 4.  Updates to RFC6550, RFC6553 and RFC8138
 
@@ -389,9 +389,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 7]
+Robles, et al.            Expires July 12, 2021                 [Page 7]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    compression should be expanded by the 6LR before it forwards a packet
@@ -445,9 +445,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 8]
+Robles, et al.            Expires July 12, 2021                 [Page 8]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    In addition, this document reserves MOP value 7 for future expansion.
@@ -501,9 +501,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                 [Page 9]
+Robles, et al.            Expires July 12, 2021                 [Page 9]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                   +------------+-----------------+---------------+
@@ -557,9 +557,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 10]
+Robles, et al.            Expires July 12, 2021                [Page 10]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    packet with a RPL Option using IPv6-in-IPv6 in all cases where it was
@@ -613,9 +613,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 11]
+Robles, et al.            Expires July 12, 2021                [Page 11]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    Hop-by-Hop RPL Option (skip over this option and continue processing
@@ -669,9 +669,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 12]
+Robles, et al.            Expires July 12, 2021                [Page 12]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    In the non-storing case, dealing with not-RPL aware leaf nodes is
@@ -725,9 +725,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 13]
+Robles, et al.            Expires July 12, 2021                [Page 13]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-+ ... -+-+ ... +-+- ... -+-+- +-+-+-+ ... +-+-+ ... -+++ ... +-...
@@ -781,9 +781,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 14]
+Robles, et al.            Expires July 12, 2021                [Page 14]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                      +------------+
@@ -837,9 +837,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 15]
+Robles, et al.            Expires July 12, 2021                [Page 15]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 6.  Use cases
@@ -893,9 +893,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 16]
+Robles, et al.            Expires July 12, 2021                [Page 16]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    As the rank information in the RPI artifact is changed at each hop,
@@ -949,9 +949,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 17]
+Robles, et al.            Expires July 12, 2021                [Page 17]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
       - Because of the above requirement, packets from the Internet have
@@ -1005,9 +1005,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 18]
+Robles, et al.            Expires July 12, 2021                [Page 18]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
       - The flow label [RFC6437] is not needed in RPL.
@@ -1061,9 +1061,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 19]
+Robles, et al.            Expires July 12, 2021                [Page 19]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------------------+--------------+------------+----------------+
@@ -1117,9 +1117,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 20]
+Robles, et al.            Expires July 12, 2021                [Page 20]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.1.1.  SM: Example of Flow from RAL to Root
@@ -1173,9 +1173,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 21]
+Robles, et al.            Expires July 12, 2021                [Page 21]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.1.2.  SM: Example of Flow from Root to RAL
@@ -1229,9 +1229,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 22]
+Robles, et al.            Expires July 12, 2021                [Page 22]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    number of routers (6LR) that the packet goes through from the 6LBR
@@ -1285,9 +1285,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 23]
+Robles, et al.            Expires July 12, 2021                [Page 23]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -1341,9 +1341,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 24]
+Robles, et al.            Expires July 12, 2021                [Page 24]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+------+--------------+----------------+-----------------+
@@ -1397,9 +1397,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 25]
+Robles, et al.            Expires July 12, 2021                [Page 25]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    RPL information from RFC 6553 may go out to Internet as it will be
@@ -1453,9 +1453,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 26]
+Robles, et al.            Expires July 12, 2021                [Page 26]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1490,8 +1490,8 @@ Internet-Draft               RPL-data-plane                 January 2020
    When the packet arrives from Internet to 6LBR the RPI is added in a
    outer IPv6-in-IPv6 header (with the IPv6-in-IPv6 destination address
    set to the RAL) and sent to 6LR, which modifies the rank in the RPI.
-   When the packet arrives at the RAL, the IPv6-in-IPv6 header is
-   decapsulated, the RPI is removed and the packet processed.
+   When the packet arrives at the RAL, the packet is decapsulated, which
+   removes the RPI before the packet is processed.
 
    The Figure 15 shows the table that summarizes what headers are needed
    for this use case.
@@ -1509,9 +1509,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 27]
+Robles, et al.            Expires July 12, 2021                [Page 27]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1565,9 +1565,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 28]
+Robles, et al.            Expires July 12, 2021                [Page 28]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+------------+-------------+-------------+--------+
@@ -1621,9 +1621,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 29]
+Robles, et al.            Expires July 12, 2021                [Page 29]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+------------+--------------+-------------+-------+
@@ -1677,9 +1677,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 30]
+Robles, et al.            Expires July 12, 2021                [Page 30]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    For example, a communication flow could be: Node F (RAL src)--> Node
@@ -1733,9 +1733,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 31]
+Robles, et al.            Expires July 12, 2021                [Page 31]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    RAL src (6LN) --> 6LR_ia --> common parent (6LBR - The root-) -->
@@ -1789,9 +1789,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 32]
+Robles, et al.            Expires July 12, 2021                [Page 32]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.3.3.  SM: Example of Flow from RUL to RAL
@@ -1845,9 +1845,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 33]
+Robles, et al.            Expires July 12, 2021                [Page 33]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+------+---------+---------+---------+---------+---------+
@@ -1901,9 +1901,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 34]
+Robles, et al.            Expires July 12, 2021                [Page 34]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    the RPI (RPI1) and inserts a new RPI (RPI2) addressed to the 6LR
@@ -1957,9 +1957,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 35]
+Robles, et al.            Expires July 12, 2021                [Page 35]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    The leaf can be a router 6LR or a host, both indicated as 6LN
@@ -2013,9 +2013,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 36]
+Robles, et al.            Expires July 12, 2021                [Page 36]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.1.  Non-Storing Mode: Interaction between Leaf and Root
@@ -2069,9 +2069,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 37]
+Robles, et al.            Expires July 12, 2021                [Page 37]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                     +-----------+-----+-------+------+
@@ -2125,9 +2125,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 38]
+Robles, et al.            Expires July 12, 2021                [Page 38]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+----------+----------+
@@ -2181,9 +2181,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 39]
+Robles, et al.            Expires July 12, 2021                [Page 39]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -2237,9 +2237,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 40]
+Robles, et al.            Expires July 12, 2021                [Page 40]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +---------+----+-----------------+-----------------+-----------------+
@@ -2293,9 +2293,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 41]
+Robles, et al.            Expires July 12, 2021                [Page 41]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    In this case, the encapsulation from the RAL to the root is optional.
@@ -2349,9 +2349,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 42]
+Robles, et al.            Expires July 12, 2021                [Page 42]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+--------------+--------------+--------------+----------+
@@ -2405,9 +2405,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 43]
+Robles, et al.            Expires July 12, 2021                [Page 43]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -2461,9 +2461,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 44]
+Robles, et al.            Expires July 12, 2021                [Page 44]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+----+-------------+--------------+--------------+--------+
@@ -2517,9 +2517,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 45]
+Robles, et al.            Expires July 12, 2021                [Page 45]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +----------+--------+------------------+-----------+-----------+-----+
@@ -2573,9 +2573,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 46]
+Robles, et al.            Expires July 12, 2021                [Page 46]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    6LR_id represents the intermediate routers from the root to the
@@ -2629,9 +2629,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 47]
+Robles, et al.            Expires July 12, 2021                [Page 47]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+----------+------------+----------+------------+
@@ -2685,9 +2685,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 48]
+Robles, et al.            Expires July 12, 2021                [Page 48]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.2.  Non-SM: Example of Flow from RAL to RUL
@@ -2741,9 +2741,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 49]
+Robles, et al.            Expires July 12, 2021                [Page 49]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+---------+---------+---------+---------+---------+------+
@@ -2797,9 +2797,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 50]
+Robles, et al.            Expires July 12, 2021                [Page 50]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.3.  Non-SM: Example of Flow from RUL to RAL
@@ -2853,9 +2853,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 51]
+Robles, et al.            Expires July 12, 2021                [Page 51]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.4.  Non-SM: Example of Flow from RUL to RUL
@@ -2909,9 +2909,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 52]
+Robles, et al.            Expires July 12, 2021                [Page 52]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 9.  Operational Considerations of supporting RUL-leaves
@@ -2965,9 +2965,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 53]
+Robles, et al.            Expires July 12, 2021                [Page 53]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 10.  Operational considerations of introducing 0x23
@@ -3021,9 +3021,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 54]
+Robles, et al.            Expires July 12, 2021                [Page 54]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-------+-------------------+------------------------+---------- -+
@@ -3077,9 +3077,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 55]
+Robles, et al.            Expires July 12, 2021                [Page 55]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 12.  Security Considerations
@@ -3133,9 +3133,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 56]
+Robles, et al.            Expires July 12, 2021                [Page 56]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    section of [RFC2473], it was suggested that tunnel entry and exit
@@ -3189,9 +3189,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 57]
+Robles, et al.            Expires July 12, 2021                [Page 57]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    very carefully inspected to match a policy that applies to this
@@ -3245,9 +3245,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 58]
+Robles, et al.            Expires July 12, 2021                [Page 58]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    L2 authentication in most of the cases.  If an attack comes from
@@ -3301,9 +3301,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 59]
+Robles, et al.            Expires July 12, 2021                [Page 59]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
@@ -3357,9 +3357,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 60]
+Robles, et al.            Expires July 12, 2021                [Page 60]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
@@ -3413,9 +3413,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 61]
+Robles, et al.            Expires July 12, 2021                [Page 61]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [I-D.ietf-roll-unaware-leaves]
@@ -3469,9 +3469,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 62]
+Robles, et al.            Expires July 12, 2021                [Page 62]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [RFC7416]  Tsao, T., Alexander, R., Dohler, M., Daza, V., Lozano, A.,
@@ -3525,4 +3525,4 @@ Authors' Addresses
 
 
 
-Robles, et al.            Expires July 11, 2021                [Page 63]
+Robles, et al.            Expires July 12, 2021                [Page 63]

--- a/roll-useofrplinfo.txt
+++ b/roll-useofrplinfo.txt
@@ -6,14 +6,14 @@ ROLL Working Group                                             M. Robles
 Internet-Draft                                             UTN-FRM/Aalto
 Updates: 6553, 6550, 8138 (if approved)                    M. Richardson
 Intended status: Standards Track                                     SSW
-Expires: July 10, 2021                                        P. Thubert
+Expires: July 12, 2021                                        P. Thubert
                                                                    Cisco
-                                                         January 6, 2020
+                                                         January 8, 2021
 
 
 Using RPI Option Type, Routing Header for Source Routes and IPv6-in-IPv6
                   encapsulation in the RPL Data Plane
-                    draft-ietf-roll-useofrplinfo-42
+                    draft-ietf-roll-useofrplinfo-43
 
 Abstract
 
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 10, 2021.
+   This Internet-Draft will expire on July 12, 2021.
 
 
 
@@ -53,14 +53,14 @@ Status of This Memo
 
 
 
-Robles, et al.            Expires July 10, 2021                 [Page 1]
+Robles, et al.            Expires July 12, 2021                 [Page 1]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 Copyright Notice
 
-   Copyright (c) 2020 IETF Trust and the persons identified as the
+   Copyright (c) 2021 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Robles, et al.            Expires July 10, 2021                 [Page 2]
+Robles, et al.            Expires July 12, 2021                 [Page 2]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
        7.3.3.  SM: Example of Flow from RUL to RAL . . . . . . . . .  33
@@ -139,7 +139,7 @@ Internet-Draft               RPL-data-plane                 January 2020
      11.1.  Option Type in RPL Option  . . . . . . . . . . . . . . .  54
      11.2.  Change to the DODAG Configuration Options Flags registry  55
      11.3.  Change MOP value 7 to Reserved . . . . . . . . . . . . .  55
-   12. Security Considerations . . . . . . . . . . . . . . . . . . .  55
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  56
    13. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  59
    14. References  . . . . . . . . . . . . . . . . . . . . . . . . .  59
      14.1.  Normative References . . . . . . . . . . . . . . . . . .  59
@@ -153,11 +153,11 @@ Internet-Draft               RPL-data-plane                 January 2020
    defines the RPL Option carried within the IPv6 Hop-by-Hop Header to
    carry the RPLInstanceID and quickly identify inconsistencies (loops)
    in the routing topology.  The RPL Option is commonly referred to as
-   the RPL Packet Information (RPI) though the RPI is really the
-   abstract information that is defined in [RFC6550] and transported in
-   the RPL Option.  RFC6554 [RFC6554] defines the "RPL Source Route
-   Header" (RH3), an IPv6 Extension Header to deliver datagrams within a
-   RPL routing domain, particularly in non-storing mode.
+   the RPL Packet Information (RPI) though the RPI is the routing
+   information that is defined in [RFC6550] and transported in the RPL
+   Option.  RFC6554 [RFC6554] defines the "RPL Source Route Header"
+   (RH3), an IPv6 Extension Header to deliver datagrams within a RPL
+   routing domain, particularly in non-storing mode.
 
    These various items are referred to as RPL artifacts, and they are
    seen on all of the data-plane traffic that occurs in RPL routed
@@ -165,9 +165,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                 [Page 3]
+Robles, et al.            Expires July 12, 2021                 [Page 3]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    traffic at all which is mostly Hop-by-Hop traffic (one exception
@@ -194,13 +194,13 @@ Internet-Draft               RPL-data-plane                 January 2020
    type 3 (RH3) [RFC6554], as well as an efficient IPv6-in-IPv6
    technique.
 
-   Most of the use cases described therein require the use of IPv6-in-
+   Most of the use cases described herein require the use of IPv6-in-
    IPv6 packet encapsulation.  When encapsulating and decapsulating
-   packets, RFC 6040 [RFC6040] MUST be applied to map the setting of the
-   explicit congestion notification (ECN) field between inner and outer
-   headers.  Additionally, [I-D.ietf-intarea-tunnels] is recommended
-   reading to explains the relationship of IP tunnels to existing
-   protocol layers and the challenges in supporting IP tunneling.
+   packets, [RFC6040] MUST be applied to map the setting of the explicit
+   congestion notification (ECN) field between inner and outer headers.
+   Additionally, [I-D.ietf-intarea-tunnels] is recommended reading to
+   explain the relationship of IP tunnels to existing protocol layers
+   and the challenges in supporting IP tunneling.
 
    Non-constrained uses of RPL are not in scope of this document, and
    applicability statements for those uses may provide different advice,
@@ -212,7 +212,7 @@ Internet-Draft               RPL-data-plane                 January 2020
    the used terminology.  Section 3 provides a RPL Overview.  Section 4
    describes the updates to RFC6553, RFC6550 and RFC 8138.  Section 5
    provides the reference topology used for the uses cases.  Section 6
-   describes the uses cases included.  Section 7 describes the storing
+   describes the use cases included.  Section 7 describes the storing
    mode cases and section 8 the non-storing mode cases.  Section 9
    describes the operational considerations of supporting RPL-unaware-
    leaves.  Section 10 depicts operational considerations for the
@@ -221,9 +221,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                 [Page 4]
+Robles, et al.            Expires July 12, 2021                 [Page 4]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 2.  Terminology and Requirements Language
@@ -252,10 +252,12 @@ Internet-Draft               RPL-data-plane                 January 2020
    encapsulation.  For simplification, this document uses the standalone
    term leaf to mean a RPL leaf.
 
-   RPL Packet Information (RPI): The abstract information that [RFC6550]
-   places in IP packets.  The term is commonly used, including in this
-   document, to refer to the RPL Option [RFC6553] that transports that
-   abstract information in an IPv6 Hop-by-Hop Header.
+   RPL Packet Information (RPI): The information defined abstractly in
+   [RFC6550] to be placed in IP packets.  The term is commonly used,
+   including in this document, to refer to the RPL Option [RFC6553] that
+   transports that abstract information in an IPv6 Hop-by-Hop Header.
+   [RFC8138] provides an alternate (more compressed) formating for the
+   same abstract information.
 
    RPL-aware-node (RAN): A device which implements RPL.  Please note
    that the device can be found inside the LLN or outside LLN.
@@ -275,11 +277,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-
-
-Robles, et al.            Expires July 10, 2021                 [Page 5]
+Robles, et al.            Expires July 12, 2021                 [Page 5]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    6LoWPAN Router (6LR): [RFC6775] defines it as:" An intermediate
@@ -296,8 +296,10 @@ Internet-Draft               RPL-data-plane                 January 2020
    network it is serving.  An isolated LoWPAN also contains a 6LBR in
    the network, which provides the prefix(es) for the isolated network."
 
-   Flag Day: In this document, refers to a transition that involves
-   having a network with different values of RPI Option Type.
+   Flag Day: It is a mechanism for resolving an interoperability
+   situation (e.g. lack of interoperation between new RPI Option Type
+   (0x23) and old RPI Option Type (0x63) nodes) by making an abrupt,
+   disruptive changeover from one to the other.
 
    Non-Storing Mode (Non-SM): RPL mode of operation in which the RPL-
    aware-nodes send information to the root about their parents.  Thus,
@@ -331,11 +333,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-
-
-Robles, et al.            Expires July 10, 2021                 [Page 6]
+Robles, et al.            Expires July 12, 2021                 [Page 6]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +--------------+
@@ -360,12 +360,14 @@ Internet-Draft               RPL-data-plane                 January 2020
 
                            Figure 1: RPL Stack.
 
-   RPL supports two modes of Downward traffic: in storing mode (SM), it
-   is fully stateful; in non-storing mode (Non-SM), it is fully source
-   routed.  A RPL Instance is either fully storing or fully non-storing,
-   i.e. a RPL Instance with a combination of storing and non-storing
-   nodes is not supported with the current specifications at the time of
-   writing this document.
+   RPL supports two modes of Downward internal traffic: in storing mode
+   (SM), it is fully stateful; in non-storing mode (Non-SM), it is fully
+   source routed.  A RPL Instance is either fully storing or fully non-
+   storing, i.e. a RPL Instance with a combination of a fully storing
+   and non-storing nodes is not supported with the current
+   specifications at the time of writing this document.  External routes
+   are advertised with non-storing-mode messaging even in a storing mode
+   network, see Section 4.1.1
 
 4.  Updates to RFC6550, RFC6553 and RFC8138
 
@@ -383,16 +385,17 @@ Internet-Draft               RPL-data-plane                 January 2020
    cannot be expected to process the [RFC8138] compression correctly.
    This means that the RPL artifacts should be contained in an IP-in-IP
    encapsulation that is removed by the 6LR, and that any remaining
+
+
+
+
+Robles, et al.            Expires July 12, 2021                 [Page 7]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    compression should be expanded by the 6LR before it forwards a packet
    outside the RPL domain.
-
-
-
-
-Robles, et al.            Expires July 10, 2021                 [Page 7]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
 
    This specification updates [RFC6550] to RECOMMEND that external
    targets are advertised using Non-Storing Mode DAO messaging even in a
@@ -402,13 +405,14 @@ Internet-Draft               RPL-data-plane                 January 2020
    informs the Root of the address of the 6LR that injects the external
    route, and the root uses IP-in-IP encapsulation to that 6LR, which
    terminates the IP-in-IP tunnel and forwards the original packet
-   outside the RPL domain free of RPL artifacts.  In the other
-   direction, for traffic coming from an external target into the LLN,
-   the parent (6LR) that injects the traffic always encapsulates to the
-   root.  This whole operation is transparent to intermediate routers
-   that only see traffic between the 6LR and the Root, and only the Root
-   and the 6LRs that inject external routes in the network need to be
-   upgraded to add this function to the network.
+   outside the RPL domain free of RPL artifacts.
+
+   In the other direction, for traffic coming from an external target
+   into the LLN, the parent (6LR) that injects the traffic always
+   encapsulates to the root.  This whole operation is transparent to
+   intermediate routers that only see traffic between the 6LR and the
+   Root, and only the Root and the 6LRs that inject external routes in
+   the network need to be upgraded to add this function to the network.
 
    A RUL is a special case of external target when the target is
    actually a host and it is known to support a consumed Routing Header
@@ -439,16 +443,16 @@ Internet-Draft               RPL-data-plane                 January 2020
    values zero (0) to six (6) only, leaving the flags unassigned for MOP
    value seven (7).The MOP is described in RFC6550 section 6.3.1.
 
+
+
+Robles, et al.            Expires July 12, 2021                 [Page 8]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    In addition, this document reserves MOP value 7 for future expansion.
 
    See Sections 11.2 and 11.3.
-
-
-
-Robles, et al.            Expires July 10, 2021                 [Page 8]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
 
 4.1.3.  Indicating the new RPI in the DODAG Configuration option Flag.
 
@@ -497,13 +501,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-
-
-
-
-Robles, et al.            Expires July 10, 2021                 [Page 9]
+Robles, et al.            Expires July 12, 2021                 [Page 9]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                   +------------+-----------------+---------------+
@@ -557,9 +557,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 10]
+Robles, et al.            Expires July 12, 2021                [Page 10]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    packet with a RPL Option using IPv6-in-IPv6 in all cases where it was
@@ -613,9 +613,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 11]
+Robles, et al.            Expires July 12, 2021                [Page 11]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    Hop-by-Hop RPL Option (skip over this option and continue processing
@@ -649,29 +649,29 @@ Internet-Draft               RPL-data-plane                 January 2020
    the network to be incrementally upgraded and allows the DODAG root to
    know which parts of the network have been upgraded.
 
-   When originating new packets, implementations SHOULD have an option
+   When originating new packets, implementations should have an option
    to determine which value to originate with, this option is controlled
-   by the DIO option described below.
+   by the DIO Configuration option (Section Section 4.1.3).
 
    The change of RPI Option Type from 0x63 to 0x23, makes all [RFC8200]
    Section 4.2 compliant nodes tolerant of the RPL artifacts.  There is
-   therefore no longer a need to remove the artifacts when sending
-   traffic to the Internet.  This change clarifies when to use IPv6-in-
-   IPv6 headers, and how to address them: The Hop-by-Hop Options header
-   containing the RPI MUST always be added when 6LRs originate packets
-   (without IPv6-in-IPv6 headers), and IPv6-in-IPv6 headers MUST always
-   be added when a 6LR finds that it needs to insert a Hop-by-Hop
-   Options header containing the RPL Option.  The IPv6-in-IPv6 header is
-   to be addressed to the RPL root when on the way up, and to the end-
-   host when on the way down.
+   no longer a need to remove the artifacts when sending traffic to the
+   Internet.  This change clarifies when to use IPv6-in-IPv6 headers,
+   and how to address them: The Hop-by-Hop Options header containing the
+   RPI MUST always be added when 6LRs originate packets (without IPv6-
+   in-IPv6 headers), and IPv6-in-IPv6 headers MUST always be added when
+   a 6LR finds that it needs to insert a Hop-by-Hop Options header
+   containing the RPL Option.  The IPv6-in-IPv6 header is to be
+   addressed to the RPL root when on the way up, and to the end-host
+   when on the way down.
 
 
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 12]
+Robles, et al.            Expires July 12, 2021                [Page 12]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    In the non-storing case, dealing with not-RPL aware leaf nodes is
@@ -725,9 +725,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 13]
+Robles, et al.            Expires July 12, 2021                [Page 13]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-+ ... -+-+ ... +-+- ... -+-+- +-+-+-+ ... +-+-+ ... -+++ ... +-...
@@ -781,9 +781,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 14]
+Robles, et al.            Expires July 12, 2021                [Page 14]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                      +------------+
@@ -837,9 +837,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 15]
+Robles, et al.            Expires July 12, 2021                [Page 15]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 6.  Use cases
@@ -893,9 +893,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 16]
+Robles, et al.            Expires July 12, 2021                [Page 16]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    As the rank information in the RPI artifact is changed at each hop,
@@ -949,9 +949,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 17]
+Robles, et al.            Expires July 12, 2021                [Page 17]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
       - Because of the above requirement, packets from the Internet have
@@ -993,9 +993,8 @@ Internet-Draft               RPL-data-plane                 January 2020
       IP encapsulation.
 
       - For traffic leaving a RUL, if the RUL adds an opaque RPI then
-      the description of the RAL applies.  The 6LR as a RPL border
-      router SHOULD rewrite the RPI to indicate the selected Instance
-      and set the flags.
+      the 6LR as a RPL border router SHOULD rewrite the RPI to indicate
+      the selected Instance and set the flags.
 
       - The description for RALs applies to RAN in general.
 
@@ -1005,9 +1004,10 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 18]
+
+Robles, et al.            Expires July 12, 2021                [Page 18]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
       - The flow label [RFC6437] is not needed in RPL.
@@ -1061,9 +1061,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 19]
+Robles, et al.            Expires July 12, 2021                [Page 19]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------------------+--------------+------------+----------------+
@@ -1117,9 +1117,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 20]
+Robles, et al.            Expires July 12, 2021                [Page 20]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.1.1.  SM: Example of Flow from RAL to Root
@@ -1173,9 +1173,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 21]
+Robles, et al.            Expires July 12, 2021                [Page 21]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.1.2.  SM: Example of Flow from Root to RAL
@@ -1229,9 +1229,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 22]
+Robles, et al.            Expires July 12, 2021                [Page 22]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    number of routers (6LR) that the packet goes through from the 6LBR
@@ -1285,9 +1285,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 23]
+Robles, et al.            Expires July 12, 2021                [Page 23]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -1341,9 +1341,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 24]
+Robles, et al.            Expires July 12, 2021                [Page 24]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+------+--------------+----------------+-----------------+
@@ -1397,9 +1397,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 25]
+Robles, et al.            Expires July 12, 2021                [Page 25]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    RPL information from RFC 6553 may go out to Internet as it will be
@@ -1453,9 +1453,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 26]
+Robles, et al.            Expires July 12, 2021                [Page 26]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1490,8 +1490,8 @@ Internet-Draft               RPL-data-plane                 January 2020
    When the packet arrives from Internet to 6LBR the RPI is added in a
    outer IPv6-in-IPv6 header (with the IPv6-in-IPv6 destination address
    set to the RAL) and sent to 6LR, which modifies the rank in the RPI.
-   When the packet arrives at the RAL the RPI is removed and the packet
-   processed.
+   When the packet arrives at the RAL, the packet is decapsulated, which
+   removes the RPI before the packet is processed.
 
    The Figure 15 shows the table that summarizes what headers are needed
    for this use case.
@@ -1509,9 +1509,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 27]
+Robles, et al.            Expires July 12, 2021                [Page 27]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -1565,9 +1565,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 28]
+Robles, et al.            Expires July 12, 2021                [Page 28]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+------------+-------------+-------------+--------+
@@ -1621,9 +1621,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 29]
+Robles, et al.            Expires July 12, 2021                [Page 29]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+------------+--------------+-------------+-------+
@@ -1677,9 +1677,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 30]
+Robles, et al.            Expires July 12, 2021                [Page 30]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    For example, a communication flow could be: Node F (RAL src)--> Node
@@ -1733,9 +1733,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 31]
+Robles, et al.            Expires July 12, 2021                [Page 31]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    RAL src (6LN) --> 6LR_ia --> common parent (6LBR - The root-) -->
@@ -1789,9 +1789,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 32]
+Robles, et al.            Expires July 12, 2021                [Page 32]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 7.3.3.  SM: Example of Flow from RUL to RAL
@@ -1845,9 +1845,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 33]
+Robles, et al.            Expires July 12, 2021                [Page 33]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+------+---------+---------+---------+---------+---------+
@@ -1901,9 +1901,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 34]
+Robles, et al.            Expires July 12, 2021                [Page 34]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    the RPI (RPI1) and inserts a new RPI (RPI2) addressed to the 6LR
@@ -1957,9 +1957,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 35]
+Robles, et al.            Expires July 12, 2021                [Page 35]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    The leaf can be a router 6LR or a host, both indicated as 6LN
@@ -2013,9 +2013,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 36]
+Robles, et al.            Expires July 12, 2021                [Page 36]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.1.  Non-Storing Mode: Interaction between Leaf and Root
@@ -2069,9 +2069,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 37]
+Robles, et al.            Expires July 12, 2021                [Page 37]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
                     +-----------+-----+-------+------+
@@ -2125,9 +2125,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 38]
+Robles, et al.            Expires July 12, 2021                [Page 38]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+----------+----------+
@@ -2181,9 +2181,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 39]
+Robles, et al.            Expires July 12, 2021                [Page 39]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+----------------+----------+
@@ -2237,9 +2237,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 40]
+Robles, et al.            Expires July 12, 2021                [Page 40]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +---------+----+-----------------+-----------------+-----------------+
@@ -2293,9 +2293,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 41]
+Robles, et al.            Expires July 12, 2021                [Page 41]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    In this case, the encapsulation from the RAL to the root is optional.
@@ -2349,9 +2349,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 42]
+Robles, et al.            Expires July 12, 2021                [Page 42]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+--------------+--------------+--------------+----------+
@@ -2405,9 +2405,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 43]
+Robles, et al.            Expires July 12, 2021                [Page 43]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-----------+----------+--------------+--------------+--------------+
@@ -2461,9 +2461,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 44]
+Robles, et al.            Expires July 12, 2021                [Page 44]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+----+-------------+--------------+--------------+--------+
@@ -2517,9 +2517,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 45]
+Robles, et al.            Expires July 12, 2021                [Page 45]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +----------+--------+------------------+-----------+-----------+-----+
@@ -2573,9 +2573,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 46]
+Robles, et al.            Expires July 12, 2021                [Page 46]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    6LR_id represents the intermediate routers from the root to the
@@ -2629,9 +2629,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 47]
+Robles, et al.            Expires July 12, 2021                [Page 47]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +---------+-------+----------+------------+----------+------------+
@@ -2685,9 +2685,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 48]
+Robles, et al.            Expires July 12, 2021                [Page 48]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.2.  Non-SM: Example of Flow from RAL to RUL
@@ -2741,9 +2741,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 49]
+Robles, et al.            Expires July 12, 2021                [Page 49]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
   +-----------+---------+---------+---------+---------+---------+------+
@@ -2797,9 +2797,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 50]
+Robles, et al.            Expires July 12, 2021                [Page 50]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.3.  Non-SM: Example of Flow from RUL to RAL
@@ -2853,9 +2853,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 51]
+Robles, et al.            Expires July 12, 2021                [Page 51]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 8.3.4.  Non-SM: Example of Flow from RUL to RUL
@@ -2909,9 +2909,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 52]
+Robles, et al.            Expires July 12, 2021                [Page 52]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 9.  Operational Considerations of supporting RUL-leaves
@@ -2926,9 +2926,9 @@ Internet-Draft               RPL-data-plane                 January 2020
    not been configured (explicitly) to examine Hop-by-Hop headers,
    should ignore those headers, and continue processing the packet.
    Despite this, and despite the switch from 0x63 to 0x23, there may be
-   hosts that are pre-RFC8200, or simply intolerant.  Those hosts will
+   nodes that are pre-RFC8200, or simply intolerant.  Those nodes will
    drop packets that continue to have RPL artifacts in them.  In
-   general, such hosts can not be easily supported in RPL LLNs.
+   general, such nodes can not be easily supported in RPL LLNs.
 
    There are some specific cases where it is possible to remove the RPL
    artifacts prior to forwarding the packet to the leaf host.  The
@@ -2965,9 +2965,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 53]
+Robles, et al.            Expires July 12, 2021                [Page 53]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
 10.  Operational considerations of introducing 0x23
@@ -2994,15 +2994,15 @@ Internet-Draft               RPL-data-plane                 January 2020
    both values .  The migration procedure is triggered when the DIO is
    sent with the flag indicating the new RPI Option Type.  Namely, it
    remains at 0x63 until it is sure that the network is capable of 0x23,
-   then it abruptly changes to 0x23.  This options allows to send
-   packets to not-RPL nodes, which should ignore the option and continue
-   processing the packets.
+   then it abruptly changes to 0x23.  The 0x23 RPI Option allows to send
+   packets to not-RPL nodes.  The not-RPL nodes should ignore the option
+   and continue processing the packets.
 
    As mentioned previously, indicating the new RPI in the DODAG
-   Configuration option flag is a way to avoid the flag day (lack of
-   interoperation) in a network using 0x63 as the RPI Option Type value.
-   It is suggested that RPL implementations accept both 0x63 and 0x23
-   RPI Option type values when processing the header to enable
+   Configuration option flag is a way to avoid the flag day (abrupt
+   changeover) in a network using 0x63 as the RPI Option Type value.  It
+   is suggested that RPL implementations accept both 0x63 and 0x23 RPI
+   Option type values when processing the header to enable
    interoperability.
 
 11.  IANA Considerations
@@ -3021,9 +3021,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 54]
+Robles, et al.            Expires July 12, 2021                [Page 54]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    +-------+-------------------+------------------------+---------- -+
@@ -3058,6 +3058,9 @@ Internet-Draft               RPL-data-plane                 January 2020
    Configuration Option Flags" registry to "DODAG Configuration Option
    Flags for MOP 0..6".
 
+   This document requests to be mentioned as a reference for this
+   change.
+
 11.3.  Change MOP value 7 to Reserved
 
    This document requests the changing the registration status of value
@@ -3067,6 +3070,18 @@ Internet-Draft               RPL-data-plane                 January 2020
    This document requests to be mentioned as a reference for this entry
    in the registry.
 
+
+
+
+
+
+
+
+Robles, et al.            Expires July 12, 2021                [Page 55]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
 12.  Security Considerations
 
    The security considerations covered in [RFC6553] and [RFC6554] apply
@@ -3074,14 +3089,6 @@ Internet-Draft               RPL-data-plane                 January 2020
 
    The IPv6-in-IPv6 mechanism described in this document is much more
    limited than the general mechanism described in [RFC2473].  The
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 55]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
-
    willingness of each node in the LLN to decapsulate packets and
    forward them could be exploited by nodes to disguise the origin of an
    attack.
@@ -3123,6 +3130,14 @@ Internet-Draft               RPL-data-plane                 January 2020
 
    Whenever IPv6-in-IPv6 headers are being proposed, there is a concern
    about creating security issues.  In the Security Considerations
+
+
+
+Robles, et al.            Expires July 12, 2021                [Page 56]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    section of [RFC2473], it was suggested that tunnel entry and exit
    points can be secured by securing the IPv6 path between them.  This
    recommendation is not practical for RPL networks.  [RFC5406] goes
@@ -3130,14 +3145,6 @@ Internet-Draft               RPL-data-plane                 January 2020
    to "Use IPsec".  Use of ESP would prevent [RFC8138] compression
    (compression must occur before encryption), and [RFC8138] compression
    is lossy in a way that prevents use of AH.  These are minor issues.
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 56]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
-
    The major issue is how to establish trust enough such that IKEv2
    could be used.  This would require a system of certificates to be
    present in every single node, including any Internet nodes that might
@@ -3179,6 +3186,14 @@ Internet-Draft               RPL-data-plane                 January 2020
    inserted in a non-storing network on traffic that is leaving the LLN,
    but this document should not preclude such a future innovation.  It
    should just be noted that an incoming RH3 must be fully consumed, or
+
+
+
+Robles, et al.            Expires July 12, 2021                [Page 57]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    very carefully inspected to match a policy that applies to this
    network and is correctly processed by the leaves.
 
@@ -3186,14 +3201,6 @@ Internet-Draft               RPL-data-plane                 January 2020
    to change the priority of a packet by selecting a different
    RPLInstanceID, perhaps one with a higher energy cost, for instance.
    It could also be that not all nodes are reachable in an LLN using the
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 57]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
-
    default RPLInstanceID, but a change of RPLInstanceID would permit an
    attacker to bypass such filtering.  Like the RH3, an RPI is to be
    inserted by the RPL root on traffic entering the LLN by first
@@ -3203,16 +3210,15 @@ Internet-Draft               RPL-data-plane                 January 2020
    second RPI will have no meaning to the end node as the packet has
    already been identified as being at it's final destination.
 
-   For traffic leaving a RUL, if the RUL adds an opaque RPI then the
-   description of the RAL applies.  The 6LR as a RPL border router
-   SHOULD rewrite the RPI to indicate the selected Instance and set the
-   flags.  This is done in order to avoid: 1) The leaf is an external
-   router that passes a packet that it did not generate and that carries
-   an unrelated RPI and 2) The leaf is an attacker or presents
-   misconfiguration and tries to inject traffic in a protected instance.
-   Also, this applies in the case where the leaf is aware of the RPL
-   instance and passes a correct RPI, the 6LR needs a configuration that
-   allows that leaf to inject in that instance.
+   For traffic leaving a RUL, if the RUL adds an opaque RPI then the 6LR
+   as a RPL border router SHOULD rewrite the RPI to indicate the
+   selected Instance and set the flags.  This is done in order to avoid:
+   1) The leaf is an external router that passes a packet that it did
+   not generate and that carries an unrelated RPI and 2) The leaf is an
+   attacker or presents misconfiguration and tries to inject traffic in
+   a protected instance.  Also, this applies in the case where the leaf
+   is aware of the RPL instance and passes a correct RPI; the 6LR needs
+   a configuration that allows that leaf to inject in that instance.
 
    The RH3 and RPIs could be abused by an attacker inside of the network
    to route packets on non-obvious ways, perhaps eluding observation.
@@ -3236,19 +3242,19 @@ Internet-Draft               RPL-data-plane                 January 2020
    [I-D.ietf-6lo-ap-nd].  The attacker will not be able to source
    traffic with an address that is not registered, and the registration
    process checks for topological correctness.  Notice that there is an
+
+
+
+Robles, et al.            Expires July 12, 2021                [Page 58]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    L2 authentication in most of the cases.  If an attack comes from
    outside LLN IPv6-in- IPv6 can be used to hide inner routing headers,
    but by construction, the RH3 can typically only address nodes within
    the LLN.  That is, an RH3 with a CmprI less than 8 , should be
    considered an attack (see RFC6554, section 3).
-
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 58]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
 
    Nodes outside of the LLN will need to pass IPv6-in-IPv6 traffic
    through the RPL root to perform this attack.  To counter, the RPL
@@ -3293,18 +3299,17 @@ Internet-Draft               RPL-data-plane                 January 2020
               Address Spoofing", BCP 38, RFC 2827, DOI 10.17487/RFC2827,
               May 2000, <https://www.rfc-editor.org/info/bcp38>.
 
+
+
+Robles, et al.            Expires July 12, 2021                [Page 59]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
-
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 59]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
 
    [RFC6040]  Briscoe, B., "Tunnelling of Explicit Congestion
               Notification", RFC 6040, DOI 10.17487/RFC6040, November
@@ -3349,18 +3354,17 @@ Internet-Draft               RPL-data-plane                 January 2020
               (6LoWPAN) Routing Header", RFC 8138, DOI 10.17487/RFC8138,
               April 2017, <https://www.rfc-editor.org/info/rfc8138>.
 
+
+
+
+Robles, et al.            Expires July 12, 2021                [Page 60]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
-
-
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 60]
-
-Internet-Draft               RPL-data-plane                 January 2020
-
 
    [RFC8200]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
               (IPv6) Specification", STD 86, RFC 8200,
@@ -3409,13 +3413,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-
-
-
-
-Robles, et al.            Expires July 10, 2021                [Page 61]
+Robles, et al.            Expires July 12, 2021                [Page 61]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [I-D.ietf-roll-unaware-leaves]
@@ -3469,9 +3469,9 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 62]
+Robles, et al.            Expires July 12, 2021                [Page 62]
 
-Internet-Draft               RPL-data-plane                 January 2020
+Internet-Draft               RPL-data-plane                 January 2021
 
 
    [RFC7416]  Tsao, T., Alexander, R., Dohler, M., Daza, V., Lozano, A.,
@@ -3497,10 +3497,10 @@ Internet-Draft               RPL-data-plane                 January 2020
 
 Authors' Addresses
 
- Maria Ines Robles
- Universidad Tecno. Nac.(UTN)-FRM, Argentina / Aalto University, Finland
+   Maria Ines Robles
+   Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
 
- Email: mariainesrobles@gmail.com
+   Email: mariainesrobles@gmail.com
 
 
    Michael C. Richardson
@@ -3525,4 +3525,4 @@ Authors' Addresses
 
 
 
-Robles, et al.            Expires July 10, 2021                [Page 63]
+Robles, et al.            Expires July 12, 2021                [Page 63]

--- a/roll-useofrplinfo.xml
+++ b/roll-useofrplinfo.xml
@@ -103,7 +103,7 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
       </address>
    </author>
 
-  <date year="2020" />
+  <date />
 
    <area>Internet</area>
 
@@ -176,7 +176,7 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
                 <xref target="RFC6554"/>, as well as an efficient IPv6-in-IPv6 technique.
              </t><t>
                 Most of the use cases described herein require the use of IPv6-in-IPv6 packet encapsulation.
-                When encapsulating and decapsulating packets, RFC 6040 [RFC6040] MUST be applied to map the
+                When encapsulating and decapsulating packets, <xref target="RFC6040"/> MUST be applied to map the
                 setting of the explicit congestion notification (ECN) field between inner and outer headers.
                 Additionally, <xref target="I-D.ietf-intarea-tunnels"/> is recommended reading to explain
                 the relationship of IP tunnels to existing protocol layers and the challenges
@@ -321,14 +321,14 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
         ]]></artwork></figure>
 </t>
         <t>
-        RPL supports two modes of Downward traffic: in storing mode (SM),
+        RPL supports two modes of Downward internal traffic: in storing mode (SM),
         it is fully stateful; in non-storing mode (Non-SM), it is fully source
         routed. A RPL Instance is either fully storing or fully
         non-storing, i.e. a RPL Instance with a combination of a fully
         storing and non-storing nodes is not supported with the
         current specifications at the time of writing this document.
-        Notice that external routes are advertised (Upwards traffic) with non-storing-mode messaging
-        even in a storing-mode network.
+        External routes are advertised with non-storing-mode messaging
+        even in a storing mode network, see <xref target="nnstext"/>
         </t>
 
 
@@ -1337,7 +1337,7 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
                         </t>
                         <t>
                         <figure title="SM: Summary of the use of headers from RUL to root." anchor="Storing-notrpl2root" align="center">
-                          <artwork><![CDATA[
+<artwork><![CDATA[
 +-----------+------+--------------+----------------+-----------------+
 |   Header  | RUL  |     6LR_1    |     6LR_i      |       6LBR dst  |
 |           | src  |              |                |                 |
@@ -2916,7 +2916,7 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
           </t>
 
           <t>This document requests to be mentioned as a reference for this change.</t>
-          
+
         </section>
         <section title="Change MOP value 7 to Reserved">
           <t>

--- a/roll-useofrplinfo.xml
+++ b/roll-useofrplinfo.xml
@@ -271,7 +271,7 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
         <t>
           Flag Day: It is a mechanism for resolving an interoperability situation
           (e.g. lack of interoperation between new RPI Option Type (0x23) and old RPI Option Type (0x63) nodes) by making an abrupt,
-           planned changeover from one to the other.
+           disruptive changeover from one to the other.
         </t>
          <t>
            Non-Storing Mode (Non-SM): RPL mode of operation in which the RPL-

--- a/roll-useofrplinfo.xml
+++ b/roll-useofrplinfo.xml
@@ -230,9 +230,11 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
         this document uses the standalone term leaf to mean a RPL leaf.
         </t>
         <t>
-        RPL Packet Information (RPI): The abstract information that <xref target="RFC6550"/> places in IP packets.
+        RPL Packet Information (RPI):
+        The information defined abstractly in <xref target="RFC6550"/> to be placed in IP packets.
         The term is commonly used, including in this document, to refer to the RPL Option <xref target="RFC6553"/>
-        that transports that abstract information in an IPv6 Hop-by-Hop Header.
+        that transports that abstract information in an IPv6 Hop-by-Hop Header. <xref target="RFC8138"/> provides
+        an alternate (more compressed) formating for the same abstract information.
         </t>
         <t>
         RPL-aware-node (RAN): A device which implements RPL. Please note that the device can be found inside the LLN or outside LLN.
@@ -1484,8 +1486,8 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
                                 the RPI is added in a outer
                                 IPv6-in-IPv6 header (with the IPv6-in-IPv6 destination address set to the RAL) and sent to 6LR, which
                                 modifies the rank in the RPI. When the packet
-                                arrives at the RAL, the IPv6-in-IPv6 header is decapsulated, the RPI is removed and the
-                                packet processed.
+                                arrives at the RAL, the packet is decapsulated, which removes the RPI before the
+                                packet is processed.
                         </t>
                         <t>
                         The <xref target="Storing-int2rpl"/> shows the table that summarizes what headers are needed for this use case.


### PR DESCRIPTION
…linfo-42: (with COMMENT)

Hello Ines:

I believe we need Michael for the flag day terminology. I do not believe that it denotes specifically a transition but rather the fact that you need to reboot the network to effectuate that transition. After all the method of using a bit also ends up in a transition, but the network can stay up during that time.

More below:

From: Ines Robles <mariainesrobles@googlemail.com>
Sent: jeudi 7 janvier 2021 18:50
To: Pascal Thubert (pthubert) <pthubert@cisco.com>; Pascal Thubert <pascal.thubert@gmail.com>
Cc: Michael Richardson <mcr+ietf@sandelman.ca>
Subject: Re: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrplinfo-42: (with COMMENT)

Hi Michael, Pascal

In the github-version the Ben's issues are addressed as follows:

....

Section 2

   Flag Day: In this document, refers to a transition that involves
   having a network with different values of RPI Option Type.

Is the flag day the act of transitioning the network from one value to
the other, or only the sub-case when it is a disruptive transition, or
...?

<ines >
transitioning the network from one value to the other.
</ines >

Section 3

   routed.  A RPL Instance is either fully storing or fully non-storing,
   i.e. a RPL Instance with a combination of storing and non-storing
   nodes is not supported with the current specifications at the time of
   writing this document.

(I assume there is no conflict between this statement and the behavior
described in Section 4.1.1 whereby external routes are advertised with
non-storing-mode messaging even in a storing-mode network.)

<ines > Added text to avoid confusion:
  <t>
        RPL supports two modes of Downward traffic: in storing mode (SM),
        it is fully stateful; in non-storing mode (Non-SM), it is fully source
        routed. A RPL Instance is either fully storing or fully
        non-storing, i.e. a RPL Instance with a combination of a fully
        storing and non-storing nodes is not supported with the
        current specifications at the time of writing this document.
        Notice that external routes are advertised (Upwards traffic) with non-storing-mode messaging
        even in a storing-mode network.
        </t>
</ines >

<Pascal>
Adding “internal”
RPL supports two modes of Downward traffic:
->
RPL supports two modes of Downward internal traffic:
</Pascal>

Section 4.1.1

   In order to enable IP-in-IP all the way to a 6LN, it is beneficial
   that the 6LN supports decapsulating IP-in-IP, but that is not assumed
   by [RFC8504].  If the 6LN is a RUL, the Root that encapsulates a
   packet SHOULD terminate the tunnel at a parent 6LR unless it is aware
   that the RUL supports IP-in-IP decapsulation.

Is there anything useful to say about how the Root would know that the
RUL supports IP-in-IP decapsulation?  ("No" is a valid answer :)

<ines > Not in the scope of this document. </ines >

Section 4.3

   This modification is required in order to be able to decompress the
   RPL Option with the new Option Type of 0x23.

nit(?): is it the RPL Option or the entire header that is decompressed?

<ines >decompress the option</ines >

Section 6

      - For traffic leaving a RUL, if the RUL adds an opaque RPI then
      the description of the RAL applies.  The 6LR as a RPL border
      router SHOULD rewrite the RPI to indicate the selected Instance
      and set the flags.

I'm not sure that I fully understand this point (specifically, "the
description of the RAL applies").  Similar text also appears in the
Security Considerations.

<ines > the description of the RAL applies, means that the 6LR has to modify the RPI that it receives from the leaf. For clarification we updated to:

For traffic leaving a RUL, if the RUL adds an opaque RPI then the 6LR as a RPL border router SHOULD rewrite the RPI to indicate the selected Instance and set the flags.

</ines >

Thanks,

Ines.

On Thu, Dec 17, 2020 at 10:48 AM Benjamin Kaduk via Datatracker <noreply@ietf.org> wrote:
Benjamin Kaduk has entered the following ballot position for
draft-ietf-roll-useofrplinfo-42: No Objection

When responding, please keep the subject line intact and reply to all
email addresses included in the To and CC lines. (Feel free to cut this
introductory paragraph, however.)

Please refer to https://www.ietf.org/iesg/statement/discuss-criteria.html
for more information about IESG DISCUSS and COMMENT positions.

The document, along with other ballot positions, can be found here:
https://datatracker.ietf.org/doc/draft-ietf-roll-useofrplinfo/

----------------------------------------------------------------------
COMMENT:
----------------------------------------------------------------------

Unfortunately, I only had time to review the diff from the -29 (that
addressed my previous batch of comments) and the -42, and was not able
to attempt to look closely at the new tables and their depiction of the
added/modified/removed/untouched headers.  As such, I do not have many
comments.

Since we are marking MOP value 7 as reserved, do we expect this document
to be listed as a reference for that entry in the registry?

Section 1

   Most of the use cases described therein require the use of IPv6-in-

nit: s/therein/herein/

Section 2

   Flag Day: In this document, refers to a transition that involves
   having a network with different values of RPI Option Type.

Is the flag day the act of transitioning the network from one value to
the other, or only the sub-case when it is a disruptive transition, or
...?

Section 3

   routed.  A RPL Instance is either fully storing or fully non-storing,
   i.e. a RPL Instance with a combination of storing and non-storing
   nodes is not supported with the current specifications at the time of
   writing this document.

(I assume there is no conflict between this statement and the behavior
described in Section 4.1.1 whereby external routes are advertised with
non-storing-mode messaging even in a storing-mode network.)

Section 4.1.1

   In order to enable IP-in-IP all the way to a 6LN, it is beneficial
   that the 6LN supports decapsulating IP-in-IP, but that is not assumed
   by [RFC8504].  If the 6LN is a RUL, the Root that encapsulates a
   packet SHOULD terminate the tunnel at a parent 6LR unless it is aware
   that the RUL supports IP-in-IP decapsulation.

Is there anything useful to say about how the Root would know that the
RUL supports IP-in-IP decapsulation?  ("No" is a valid answer :)

Section 4.3

   This modification is required in order to be able to decompress the
   RPL Option with the new Option Type of 0x23.

nit(?): is it the RPL Option or the entire header that is decompressed?

Section 6

      - For traffic leaving a RUL, if the RUL adds an opaque RPI then
      the description of the RAL applies.  The 6LR as a RPL border
      router SHOULD rewrite the RPI to indicate the selected Instance
      and set the flags.

I'm not sure that I fully understand this point (specifically, "the
description of the RAL applies").  Similar text also appears in the
Security Considerations.

Section 8.2.4

There seem to be some changes in the table compared to the -29; were
these verified to be correct?

Section 12

   Also, this applies in the case where the leaf is aware of the RPL
   instance and passes a correct RPI, the 6LR needs a configuration that
   allows that leaf to inject in that instance.

nit: the second comma should probably be a colon or em dash.