### PR TITLE
Subject: Re: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrp…

### DIFF
--- a/roll-useofrplinfo.txt
+++ b/roll-useofrplinfo.txt
@@ -6,14 +6,14 @@ ROLL Working Group                                             M. Robles
 Internet-Draft                                             UTN-FRM/Aalto
 Updates: 6553, 6550, 8138 (if approved)                    M. Richardson
 Intended status: Standards Track                                     SSW
-Expires: July 12, 2021                                        P. Thubert
+Expires: July 18, 2021                                        P. Thubert
                                                                    Cisco
-                                                         January 8, 2021
+                                                        January 14, 2021
 
 
 Using RPI Option Type, Routing Header for Source Routes and IPv6-in-IPv6
                   encapsulation in the RPL Data Plane
-                    draft-ietf-roll-useofrplinfo-43
+                    draft-ietf-roll-useofrplinfo-44
 
 Abstract
 
@@ -44,7 +44,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 12, 2021.
+   This Internet-Draft will expire on July 18, 2021.
 
 
 
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 1]
+Robles, et al.            Expires July 18, 2021                 [Page 1]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 2]
+Robles, et al.            Expires July 18, 2021                 [Page 2]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -142,7 +142,7 @@ Internet-Draft               RPL-data-plane                 January 2021
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  56
    13. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  59
    14. References  . . . . . . . . . . . . . . . . . . . . . . . . .  59
-     14.1.  Normative References . . . . . . . . . . . . . . . . . .  59
+     14.1.  Normative References . . . . . . . . . . . . . . . . . .  60
      14.2.  Informative References . . . . . . . . . . . . . . . . .  61
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  63
 
@@ -165,7 +165,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 3]
+Robles, et al.            Expires July 18, 2021                 [Page 3]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -221,7 +221,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 4]
+Robles, et al.            Expires July 18, 2021                 [Page 4]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -277,7 +277,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 5]
+Robles, et al.            Expires July 18, 2021                 [Page 5]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -333,7 +333,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 6]
+Robles, et al.            Expires July 18, 2021                 [Page 6]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -389,7 +389,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 7]
+Robles, et al.            Expires July 18, 2021                 [Page 7]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -445,7 +445,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 8]
+Robles, et al.            Expires July 18, 2021                 [Page 8]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -501,7 +501,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                 [Page 9]
+Robles, et al.            Expires July 18, 2021                 [Page 9]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -557,7 +557,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 10]
+Robles, et al.            Expires July 18, 2021                [Page 10]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -613,7 +613,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 11]
+Robles, et al.            Expires July 18, 2021                [Page 11]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -669,7 +669,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 12]
+Robles, et al.            Expires July 18, 2021                [Page 12]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -725,7 +725,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 13]
+Robles, et al.            Expires July 18, 2021                [Page 13]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -781,7 +781,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 14]
+Robles, et al.            Expires July 18, 2021                [Page 14]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -837,7 +837,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 15]
+Robles, et al.            Expires July 18, 2021                [Page 15]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -893,7 +893,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 16]
+Robles, et al.            Expires July 18, 2021                [Page 16]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -949,7 +949,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 17]
+Robles, et al.            Expires July 18, 2021                [Page 17]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1005,7 +1005,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 18]
+Robles, et al.            Expires July 18, 2021                [Page 18]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1061,7 +1061,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 19]
+Robles, et al.            Expires July 18, 2021                [Page 19]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1117,7 +1117,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 20]
+Robles, et al.            Expires July 18, 2021                [Page 20]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1173,7 +1173,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 21]
+Robles, et al.            Expires July 18, 2021                [Page 21]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1229,7 +1229,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 22]
+Robles, et al.            Expires July 18, 2021                [Page 22]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1285,7 +1285,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 23]
+Robles, et al.            Expires July 18, 2021                [Page 23]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1341,7 +1341,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 24]
+Robles, et al.            Expires July 18, 2021                [Page 24]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1397,7 +1397,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 25]
+Robles, et al.            Expires July 18, 2021                [Page 25]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1453,7 +1453,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 26]
+Robles, et al.            Expires July 18, 2021                [Page 26]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1509,7 +1509,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 27]
+Robles, et al.            Expires July 18, 2021                [Page 27]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1565,7 +1565,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 28]
+Robles, et al.            Expires July 18, 2021                [Page 28]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1621,7 +1621,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 29]
+Robles, et al.            Expires July 18, 2021                [Page 29]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1677,7 +1677,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 30]
+Robles, et al.            Expires July 18, 2021                [Page 30]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1733,7 +1733,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 31]
+Robles, et al.            Expires July 18, 2021                [Page 31]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1789,7 +1789,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 32]
+Robles, et al.            Expires July 18, 2021                [Page 32]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1845,7 +1845,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 33]
+Robles, et al.            Expires July 18, 2021                [Page 33]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1901,7 +1901,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 34]
+Robles, et al.            Expires July 18, 2021                [Page 34]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -1957,7 +1957,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 35]
+Robles, et al.            Expires July 18, 2021                [Page 35]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2013,7 +2013,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 36]
+Robles, et al.            Expires July 18, 2021                [Page 36]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2069,7 +2069,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 37]
+Robles, et al.            Expires July 18, 2021                [Page 37]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2125,7 +2125,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 38]
+Robles, et al.            Expires July 18, 2021                [Page 38]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2181,7 +2181,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 39]
+Robles, et al.            Expires July 18, 2021                [Page 39]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2237,7 +2237,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 40]
+Robles, et al.            Expires July 18, 2021                [Page 40]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2293,7 +2293,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 41]
+Robles, et al.            Expires July 18, 2021                [Page 41]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2349,7 +2349,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 42]
+Robles, et al.            Expires July 18, 2021                [Page 42]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2405,7 +2405,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 43]
+Robles, et al.            Expires July 18, 2021                [Page 43]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2461,7 +2461,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 44]
+Robles, et al.            Expires July 18, 2021                [Page 44]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2517,7 +2517,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 45]
+Robles, et al.            Expires July 18, 2021                [Page 45]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2573,7 +2573,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 46]
+Robles, et al.            Expires July 18, 2021                [Page 46]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2629,7 +2629,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 47]
+Robles, et al.            Expires July 18, 2021                [Page 47]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2685,7 +2685,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 48]
+Robles, et al.            Expires July 18, 2021                [Page 48]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2741,7 +2741,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 49]
+Robles, et al.            Expires July 18, 2021                [Page 49]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2797,7 +2797,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 50]
+Robles, et al.            Expires July 18, 2021                [Page 50]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2853,7 +2853,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 51]
+Robles, et al.            Expires July 18, 2021                [Page 51]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2909,7 +2909,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 52]
+Robles, et al.            Expires July 18, 2021                [Page 52]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -2965,7 +2965,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 53]
+Robles, et al.            Expires July 18, 2021                [Page 53]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -3021,7 +3021,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 54]
+Robles, et al.            Expires July 18, 2021                [Page 54]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -3077,7 +3077,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 55]
+Robles, et al.            Expires July 18, 2021                [Page 55]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -3133,7 +3133,7 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 56]
+Robles, et al.            Expires July 18, 2021                [Page 56]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
@@ -3166,36 +3166,39 @@ Internet-Draft               RPL-data-plane                 January 2021
    An LLN with hostile nodes within it would not be protected against
    impersonation with the LLN by entry/exit filtering.
 
-   The RH3 header usage described here can be abused in equivalent ways
-   (to disguise the origin of traffic and attack other nodes) with an
-   IPv6-in-IPv6 header to add the needed RH3 header.  As such, the
-   attacker's RH3 header will not be seen by the network until it
-   reaches the end host, which will decapsulate it.  An end-host should
-   be suspicious about an RH3 header which has additional hops which
-   have not yet been processed, and SHOULD ignore such a second RH3
-   header.
+   The RH3 header usage described here can be abused in equivalent ways.
+   An external attacker may form a packet with an RH3 that is not fully
+   consumed and encapsulate it to hide the RH3 from intermediate nodes
+   and disguise the origin of traffic.  As such, the attacker's RH3
+   header will not be seen by the network until it reaches the
+   destination, which will decapsulate it.  As indicated in section 4.2
+   of [RFC6554], RPL routers are responsible for ensuring that an SRH is
+   only used between RPL routers.  As such, if there is an RH3 that is
+   not fully consumed in the encapsulated packet, the node that
+   decapsulates it MUST ensure that the outer packet was originated in
+   the RPL domain and drop the packet otherwise.
 
-   In addition, the LLN will likely use [RFC8138] to compress the IPv6-
-   in-IPv6 and RH3 headers.  As such, the compressor at the RPL-root
-   will see the second RH3 header and MAY choose to discard the packet
-   if the RH3 header has not been completely consumed.  A consumed
-   (inert) RH3 header could be present in a packet that flows from one
-   LLN, crosses the Internet, and enters another LLN.  As per the
-   discussion in this document, such headers do not need to be removed.
-   However, there is no case described in this document where an RH3 is
-   inserted in a non-storing network on traffic that is leaving the LLN,
-   but this document should not preclude such a future innovation.  It
-   should just be noted that an incoming RH3 must be fully consumed, or
+   Also, as indicated by section 2 of [RFC6554], RPL Border Routers "do
+   not allow datagrams carrying an SRH header to enter or exit a RPL
+   routing domain".  This sentence must be understood as concerning non-
+   fully-consumed packets.  A consumed (inert) RH3 header could be
+   present in a packet that flows from one LLN, crosses the Internet,
+   and enters another LLN.  As per the discussion in this document, such
+   headers do not need to be removed.  However, there is no case
+   described in this document where an RH3 is inserted in a non-storing
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 57]
+Robles, et al.            Expires July 18, 2021                [Page 57]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
 
-   very carefully inspected to match a policy that applies to this
-   network and is correctly processed by the leaves.
+   network on traffic that is leaving the LLN, but this document should
+   not preclude such a future innovation.
+
+   In short, a packet that crosses the border of the RPL domain MAY
+   carry and RH3, and if so, that RH3 MUST be fully consumed.
 
    The RPI, if permitted to enter the LLN, could be used by an attacker
    to change the priority of a packet by selecting a different
@@ -3239,17 +3242,17 @@ Internet-Draft               RPL-data-plane                 January 2021
 
    If an attack comes from inside of LLN, it can be alleviated with SAVI
    (Source Address Validation Improvement) using [RFC8505] with
-   [I-D.ietf-6lo-ap-nd].  The attacker will not be able to source
-   traffic with an address that is not registered, and the registration
-   process checks for topological correctness.  Notice that there is an
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 58]
+Robles, et al.            Expires July 18, 2021                [Page 58]
 
 Internet-Draft               RPL-data-plane                 January 2021
 
 
+   [I-D.ietf-6lo-ap-nd].  The attacker will not be able to source
+   traffic with an address that is not registered, and the registration
+   process checks for topological correctness.  Notice that there is an
    L2 authentication in most of the cases.  If an attack comes from
    outside LLN IPv6-in- IPv6 can be used to hide inner routing headers,
    but by construction, the RH3 can typically only address nodes within
@@ -3292,19 +3295,23 @@ Internet-Draft               RPL-data-plane                 January 2021
 
 14.  References
 
+
+
+
+
+
+
+Robles, et al.            Expires July 18, 2021                [Page 59]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
 14.1.  Normative References
 
    [BCP38]    Ferguson, P. and D. Senie, "Network Ingress Filtering:
               Defeating Denial of Service Attacks which employ IP Source
               Address Spoofing", BCP 38, RFC 2827, DOI 10.17487/RFC2827,
               May 2000, <https://www.rfc-editor.org/info/bcp38>.
-
-
-
-Robles, et al.            Expires July 12, 2021                [Page 59]
-
-Internet-Draft               RPL-data-plane                 January 2021
-
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -3344,6 +3351,17 @@ Internet-Draft               RPL-data-plane                 January 2021
               DOI 10.17487/RFC7045, December 2013,
               <https://www.rfc-editor.org/info/rfc7045>.
 
+
+
+
+
+
+
+Robles, et al.            Expires July 18, 2021                [Page 60]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    [RFC8025]  Thubert, P., Ed. and R. Cragie, "IPv6 over Low-Power
               Wireless Personal Area Network (6LoWPAN) Paging Dispatch",
               RFC 8025, DOI 10.17487/RFC8025, November 2016,
@@ -3353,14 +3371,6 @@ Internet-Draft               RPL-data-plane                 January 2021
               "IPv6 over Low-Power Wireless Personal Area Network
               (6LoWPAN) Routing Header", RFC 8138, DOI 10.17487/RFC8138,
               April 2017, <https://www.rfc-editor.org/info/rfc8138>.
-
-
-
-
-Robles, et al.            Expires July 12, 2021                [Page 60]
-
-Internet-Draft               RPL-data-plane                 January 2021
-
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
@@ -3400,6 +3410,14 @@ Internet-Draft               RPL-data-plane                 January 2021
               Control Plane (ACP)", draft-ietf-anima-autonomic-control-
               plane-30 (work in progress), October 2020.
 
+
+
+
+Robles, et al.            Expires July 18, 2021                [Page 61]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    [I-D.ietf-anima-bootstrapping-keyinfra]
               Pritikin, M., Richardson, M., Eckert, T., Behringer, M.,
               and K. Watsen, "Bootstrapping Remote Secure Key
@@ -3411,17 +3429,10 @@ Internet-Draft               RPL-data-plane                 January 2021
               Architecture", draft-ietf-intarea-tunnels-10 (work in
               progress), September 2019.
 
-
-
-Robles, et al.            Expires July 12, 2021                [Page 61]
-
-Internet-Draft               RPL-data-plane                 January 2021
-
-
    [I-D.ietf-roll-unaware-leaves]
               Thubert, P. and M. Richardson, "Routing for RPL Leaves",
-              draft-ietf-roll-unaware-leaves-28 (work in progress),
-              December 2020.
+              draft-ietf-roll-unaware-leaves-29 (work in progress),
+              January 2021.
 
    [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
               (IPv6) Specification", RFC 2460, DOI 10.17487/RFC2460,
@@ -3452,6 +3463,17 @@ Internet-Draft               RPL-data-plane                 January 2021
               RFC 6775, DOI 10.17487/RFC6775, November 2012,
               <https://www.rfc-editor.org/info/rfc6775>.
 
+
+
+
+
+
+
+Robles, et al.            Expires July 18, 2021                [Page 62]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    [RFC6997]  Goyal, M., Ed., Baccelli, E., Philipp, M., Brandt, A., and
               J. Martocci, "Reactive Discovery of Point-to-Point Routes
               in Low-Power and Lossy Networks", RFC 6997,
@@ -3461,18 +3483,6 @@ Internet-Draft               RPL-data-plane                 January 2021
    [RFC7102]  Vasseur, JP., "Terms Used in Routing for Low-Power and
               Lossy Networks", RFC 7102, DOI 10.17487/RFC7102, January
               2014, <https://www.rfc-editor.org/info/rfc7102>.
-
-
-
-
-
-
-
-
-Robles, et al.            Expires July 12, 2021                [Page 62]
-
-Internet-Draft               RPL-data-plane                 January 2021
-
 
    [RFC7416]  Tsao, T., Alexander, R., Dohler, M., Daza, V., Lozano, A.,
               and M. Richardson, Ed., "A Security Threat Analysis for
@@ -3513,6 +3523,13 @@ Authors' Addresses
    URI:   http://www.sandelman.ca/mcr/
 
 
+
+
+Robles, et al.            Expires July 18, 2021                [Page 63]
+
+Internet-Draft               RPL-data-plane                 January 2021
+
+
    Pascal Thubert
    Cisco Systems, Inc
    Building D
@@ -3525,4 +3542,43 @@ Authors' Addresses
 
 
 
-Robles, et al.            Expires July 12, 2021                [Page 63]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Robles, et al.            Expires July 18, 2021                [Page 64]

--- a/roll-useofrplinfo.xml
+++ b/roll-useofrplinfo.xml
@@ -48,7 +48,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="std" docName="draft-ietf-roll-useofrplinfo-43" ipr="trust200902" updates="6553, 6550, 8138">
+<rfc category="std" docName="draft-ietf-roll-useofrplinfo-44" ipr="trust200902" updates="6553, 6550, 8138">
  <!-- category values: std, bcp, info, exp, and historic
     ipr values: trust200902, noModificationTrust200902, noDerivativesTrust200902,
        or pre5378Trust200902
@@ -3026,30 +3026,35 @@ Universidad Tecno. Nac.(UTN)-FRM, Argentina/ Aalto University Finland
 
           <t>
             The RH3 header usage described here can be abused in equivalent
-            ways (to disguise the origin of traffic and attack other nodes)
-            with an IPv6-in-IPv6 header to add the needed RH3
-            header. As such, the attacker's RH3 header will not be seen by
-            the network until it reaches the end host, which will decapsulate
-            it.  An end-host should be suspicious about an RH3 header which
-            has additional hops which have not yet been processed, and SHOULD
-            ignore such a second RH3 header.
+            ways. An external attacker may form a packet with an RH3 that is
+            not fully consumed and encapsulate it to hide the RH3 from
+            intermediate nodes and disguise the origin of
+            traffic. As such, the attacker's RH3 header will not be seen by
+            the network until it reaches the destination, which will decapsulate
+            it. As indicated in section 4.2 of <xref target="RFC6554"/>, RPL
+            routers are responsible for ensuring that an SRH is only used
+            between RPL routers. As such, if there is an RH3 that is not fully
+            consumed in the encapsulated packet, the node that decapsulates it
+            MUST ensure that the outer packet was originated in the RPL domain
+            and drop the packet otherwise.
           </t>
           <t>
-            In addition, the LLN will likely use <xref
-            target="RFC8138" /> to compress the IPv6-in-IPv6
-            and RH3 headers. As such, the compressor at the RPL-root will see
-            the second RH3 header and MAY choose to discard the packet if the
-            RH3 header has not been completely consumed.  A consumed (inert)
+            Also, as indicated by section 2 of
+            <xref target="RFC6554"/>, RPL Border Routers "do not allow datagrams
+            carrying an SRH header to enter or exit a RPL routing domain". This
+            sentence must be understood as concerning non-fully-consumed packets.
+            A consumed (inert)
             RH3 header could be present in a packet that flows from one LLN,
             crosses the Internet, and enters another LLN.  As per the
             discussion in this document, such headers do not need to be
             removed.  However, there is no case described in this document
             where an RH3 is inserted in a non-storing network on traffic that
             is leaving the LLN, but this document should not preclude such a
-            future innovation.  It should just be noted that an incoming RH3
-            must be fully consumed, or very carefully inspected to match a
-            policy that applies to this network and is correctly processed by
-            the leaves.
+            future innovation.
+          </t>
+          <t>
+            In short, a packet that crosses the border of the RPL domain MAY
+            carry and RH3, and if so, that RH3 MUST be fully consumed.
           </t>
           <t>
             The RPI, if permitted to enter the LLN, could be used by


### PR DESCRIPTION
…linfo-42

What about :

          <t>
            The RH3 header usage described here can be abused in equivalent
            ways. An external attacker may form a packet with an RH3 that is
            not fully consumed and encapsulate it to hide the RH3 from
            intermediate nodes and disguise the origin of
            traffic. As such, the attacker's RH3 header will not be seen by
            the network until it reaches the destination, which will decapsulate
            it. As indicated in section 4.2 of <xref target="RFC6554"/>, RPL
            routers are responsible for ensuring that an SRH is only used
            between RPL routers. As such, if there is an RH3 that is not fully
            consumed in the encapsulated packet, the node that decapsulates it
            MUST ensure that the outer packet was originated in the RPL domain
            and drop the packet otherwise.
          </t>
          <t>
            Also, as indicated by section 2 of
            <xref target="RFC6554"/>, RPL Border Routers "do not allow datagrams
            carrying an SRH header to enter or exit a RPL routing domain". This
            sentence must be understood as concerning non-fully-consumed packets.
            A consumed (inert)
            RH3 header could be present in a packet that flows from one LLN,
            crosses the Internet, and enters another LLN.  As per the
            discussion in this document, such headers do not need to be
            removed.  However, there is no case described in this document
            where an RH3 is inserted in a non-storing network on traffic that
            is leaving the LLN, but this document should not preclude such a
            future innovation.
          </t>
          <t>
            In short, a packet that crosses the border of the RPL domain MAY
            carry and RH3, and if so, that RH3 MUST be fully consumed.
          </t>

From: Pascal Thubert (pthubert)
Sent: jeudi 14 janvier 2021 14:12
To: Ines Robles <mariainesrobles@googlemail.com>
Cc: Michael Richardson <mcr@sandelman.ca>; Pascal Thubert <pascal.thubert@gmail.com>
Subject: RE: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrplinfo-42: (with COMMENT)

We must do that, for sure. I’m reviewing the text that’s really hard to understand…

From: Ines Robles <mariainesrobles@googlemail.com>
Sent: jeudi 14 janvier 2021 13:53
To: Pascal Thubert (pthubert) <pthubert@cisco.com>
Cc: Michael Richardson <mcr@sandelman.ca>; Pascal Thubert <pascal.thubert@gmail.com>
Subject: Re: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrplinfo-42: (with COMMENT)

Thank you very much Pascal and Michael,

I am available tomorrow after 3pm UTC.

Ok,  from the discussion: " Erik recommend referring to RFC 6554 S4.2 for how to handle RH3's if the node is also a RPL-aware router and say it MUST drop the packet if segments left is non-zero and it's not a RPL-aware router." maybe we should do just that, would it be ok?

thanks,
ines.

On Thu, Jan 14, 2021 at 2:37 PM Pascal Thubert (pthubert) <pthubert@cisco.com> wrote:
I had a chat with Alvaro; he's waiting for the DISCUSS from Erik.
Sadlt 43 does not address that DISCUSS.

The offending text is
"
   The RH3 header usage described here can be abused in equivalent ways
   (to disguise the origin of traffic and attack other nodes) with an
   IPv6-in-IPv6 header to add the needed RH3 header.  As such, the
   attacker's RH3 header will not be seen by the network until it
   reaches the end host, which will decapsulate it.  An end-host should
   be suspicious about an RH3 header which has additional hops which
   have not yet been processed, and SHOULD ignore such a second RH3
   header.

   In addition, the LLN will likely use [RFC8138] to compress the IPv6-
   in-IPv6 and RH3 headers.  As such, the compressor at the RPL-root
   will see the second RH3 header and MAY choose to discard the packet
   if the RH3 header has not been completely consumed.  A consumed
   (inert) RH3 header could be present in a packet that flows from one
   LLN, crosses the Internet, and enters another LLN.  As per the
   discussion in this document, such headers do not need to be removed.
   However, there is no case described in this document where an RH3 is
   inserted in a non-storing network on traffic that is leaving the LLN,
   but this document should not preclude such a future innovation.  It
   should just be noted that an incoming RH3 must be fully consumed, or
   very carefully inspected to match a policy that applies to this
   network and is correctly processed by the leaves.
"

This text is hard to read and makes little sense for the most part since the incoming packet from the Internet will be encapsulated so there will not be 2 RH2 even if the incoming packet has one.

I'm on it, will propose a pull, but happy to discuss what we really want to say. My answer is to indicate that there is encaps and that the inner packet MUST be consumed as Erik says when processed by a Host. Since the root does not know whether the leaf is a host or an external router, there's little we can do beyond applying a policy.

Thoughts? Call?

Pascal

> -----Original Message-----
> From: Michael Richardson <mcr@sandelman.ca>
> Sent: jeudi 14 janvier 2021 13:29
> To: Pascal Thubert (pthubert) <pthubert@cisco.com>
> Cc: Ines Robles <mariainesrobles@googlemail.com>; Pascal Thubert
> <pascal.thubert@gmail.com>
> Subject: Re: Benjamin Kaduk's No Objection on draft-ietf-roll-useofrplinfo-42:
> (with COMMENT)
>
>
> Pascal Thubert (pthubert) <pthubert@cisco.com> wrote:
>     > Inès pulled and published. Can you please check the new definition in
>     > -43? We avoided the term reboot but used disruptive that was present in
>     > a reviewer suggestion.
>
> Yes, I know I'm late on reviewing.
> I'm checking -43 now.